### PR TITLE
More Mac improvements:

### DIFF
--- a/src/macosx/AboutBox.h
+++ b/src/macosx/AboutBox.h
@@ -25,18 +25,18 @@
 */
 @interface AboutBox : NSObject
 {
-  IBOutlet id appNameField;
-  IBOutlet id creditsField;
-  IBOutlet id versionField;
+  IBOutlet NSTextField *appNameField;
+  IBOutlet NSTextView *creditsField;
+  IBOutlet NSTextField *versionField;
   NSTimer *scrollTimer;
-  float currentPosition;
-  float maxScrollHeight;
+  CGFloat currentPosition;
+  CGFloat maxScrollHeight;
   NSTimeInterval startTime;
   BOOL restartAtTop;
 }
 
 + (AboutBox *)sharedInstance;
 - (IBAction)showPanel:(id)sender;
-- (void)OK:(id)sender;
+- (IBAction)OK:(id)sender;
 
 @end

--- a/src/macosx/AboutBox.m
+++ b/src/macosx/AboutBox.m
@@ -29,7 +29,7 @@ static AboutBox *sharedInstance = nil;
 - (id)init
 {
   if (sharedInstance)
-    [self dealloc];
+    [self release];
   else
     sharedInstance = [super init];
 

--- a/src/macosx/Preferences.m
+++ b/src/macosx/Preferences.m
@@ -46,17 +46,27 @@ static Preferences *sharedInstance = nil;
 - (id)init
 {
   if (self = [super init]) {
-    defaults = [NSUserDefaults standardUserDefaults];
+    defaults = [[NSUserDefaults standardUserDefaults] retain];
     sharedInstance = self;
   }
   return(self);
 }
 
+- (void)dealloc
+{
+  [defaults release];
+  if (self == sharedInstance) {
+    sharedInstance = nil;
+  }
+  
+  [super dealloc];
+}
+
 - (void)setString:(const char *)key : (const char *)value
 {
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-  NSString* theKey   = [NSString stringWithCString:key encoding:NSASCIIStringEncoding];
-  NSString* theValue = [NSString stringWithCString:value encoding:NSASCIIStringEncoding];
+  NSString* theKey   = [NSString stringWithCString:key encoding:NSUTF8StringEncoding];
+  NSString* theValue = [NSString stringWithCString:value encoding:NSUTF8StringEncoding];
 
   [defaults setObject:theValue forKey:theKey];
   [pool release];
@@ -65,10 +75,10 @@ static Preferences *sharedInstance = nil;
 - (void)getString:(const char *)key : (char *)value : (int)size
 {
   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-  NSString* theKey   = [NSString stringWithCString:key encoding:NSASCIIStringEncoding];
+  NSString* theKey   = [NSString stringWithCString:key encoding:NSUTF8StringEncoding];
   NSString* theValue = [defaults objectForKey:theKey];
   if (theValue != nil)
-    strncpy(value, [theValue cStringUsingEncoding: NSASCIIStringEncoding], size);
+    strncpy(value, [theValue cStringUsingEncoding: NSUTF8StringEncoding], size);
   else
     value[0] = 0;
 


### PR DESCRIPTION
Use UTF-8 for saving/getting preferences: It's more reliable.
Retain defaults in the Preferences Objective-C class.
Fill out the types for the IBOutlet