### PR TITLE
Fix relative include for FrameManager.hxx

### DIFF
--- a/src/emucore/TIASurface.hxx
+++ b/src/emucore/TIASurface.hxx
@@ -25,7 +25,7 @@ class FrameBuffer;
 class FBSurface;
 class VideoMode;
 
-#include "FrameManager.hxx"
+#include "tia/FrameManager.hxx"
 #include "Rect.hxx"
 #include "NTSCFilter.hxx"
 #include "bspf.hxx"


### PR DESCRIPTION
TIASurface.hxx includes FrameManager.hxx, which exists in the `tia` folder. This fixes the relative include.