### PR TITLE
Fix error when building with uClibc-ng for ARM

### DIFF
--- a/src/emucore/tia/PaddleReader.cxx
+++ b/src/emucore/tia/PaddleReader.cxx
@@ -22,7 +22,6 @@
 static constexpr double
   C = 68e-9,
   RPOT = 1e6,
-  R0 = 1.5e3,
   USUPP = 5;
 
 static constexpr double TRIPPOINT_LINES = 379;

--- a/src/emucore/tia/PaddleReader.hxx
+++ b/src/emucore/tia/PaddleReader.hxx
@@ -65,6 +65,8 @@ class PaddleReader : public Serializable
 
     bool myIsDumped;
 
+    static constexpr double R0 = 1.5e3;
+
   private:
     PaddleReader(const PaddleReader&) = delete;
     PaddleReader(PaddleReader&&) = delete;


### PR DESCRIPTION
The uClibc-ng C library defines a type called R0 when compiling for ARM,
that conflits with a global variable called R0 from PaddleReader.cxx.

src/emucore/tia/PaddleReader.cxx:25:3: error: ‘constexpr const double R0’ redeclared as different kind of symbol
   R0 = 1.5e3,
   ^
/home/sprado/workspace/build/buildroot/build/stella_uclibc/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/sys/ucontext.h:42:3: note: previous declaration ‘<anonymous enum> R0’
   R0 = 0,
   ^~

So let's redefine R0 as a private member of the PaddleReader class.

Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>