### PR TITLE
Fixed removal of prefix of local labels (global.local -> .local).

### DIFF
--- a/src/debugger/CartDebug.cxx
+++ b/src/debugger/CartDebug.cxx
@@ -786,7 +786,8 @@ string CartDebug::loadSymbolFile()
       if (iter == myUserLabels.end() || !BSPF::equalsIgnoreCase(label, iter->second))
       {
         // Check for period, and strip leading number
-        if(string::size_type pos = label.find_first_of(".", 0) != string::npos)
+        string::size_type pos = label.find_first_of(".", 0);
+        if(pos != string::npos)
           addLabel(label.substr(pos), value);
         else
           addLabel(label, value);


### PR DESCRIPTION
Wrong operator precedence was used : pos was assigned the comparision of the search for '.' with string::npos, giving 1. Hence, only first character of local label was stripped instead of everything up to the first dot.