### PR TITLE
Spelling fixes

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -2680,7 +2680,7 @@
 
   * Fixed crash when adding one-shot cheats.
 
-  * Fixed bug in RAM comparitive searches in the debugger.
+  * Fixed bug in RAM comparative searches in the debugger.
 
   * Fixed bug with setting snapshot naming type from the GUI (it was
     always being set to 'romname').

--- a/docs/debugger.html
+++ b/docs/debugger.html
@@ -957,7 +957,7 @@ and the input is empty, all RAM locations are highlighted.</p>
 
 <p>The 'Compare' button is used to compare the given value using all
 addresses currently highlighted.  This may be an absolute number (such as 2),
-or a comparitive number (such as -1).  Using a '+' or '-' operator
+or a comparative number (such as -1).  Using a '+' or '-' operator
 means 'search addresses for values that have changed by that amount'.</p>
 <p>The 'Reset' button resets the entire operation; it clears the highlighted
 addresses and allows another search.</p>

--- a/src/debugger/gui/RamWidget.cxx
+++ b/src/debugger/gui/RamWidget.cxx
@@ -383,11 +383,11 @@ string RamWidget::doSearch(const string& str)
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 string RamWidget::doCompare(const string& str)
 {
-  bool comparitiveSearch = false;
+  bool comparativeSearch = false;
   int searchVal = 0, offset = 0;
 
   if(str.length() == 0)
-    return "Enter an absolute or comparitive value";
+    return "Enter an absolute or comparative value";
 
   // Do some pre-processing on the string
   string::size_type pos = str.find_first_of("+-", 0);
@@ -397,11 +397,11 @@ string RamWidget::doCompare(const string& str)
     return "Input must be [+|-]NUM";
   }
 
-  // A comparitive search searches memory for locations that have changed by
+  // A comparative search searches memory for locations that have changed by
   // the specified amount, vs. for exact values
   if(str[0] == '+' || str[0] == '-')
   {
-    comparitiveSearch = true;
+    comparativeSearch = true;
     bool negative = false;
     if(str[0] == '-')
       negative = true;
@@ -425,7 +425,7 @@ string RamWidget::doCompare(const string& str)
 
   for(uInt32 i = 0; i < mySearchAddr.size(); ++i)
   {
-    if(comparitiveSearch)
+    if(comparativeSearch)
     {
       searchVal = mySearchValue[i] + offset;
       if(searchVal < 0 || searchVal > 255)

--- a/src/emucore/Settings.cxx
+++ b/src/emucore/Settings.cxx
@@ -555,7 +555,7 @@ void Settings::saveConfig()
       << ";  Format MUST be as follows:" << endl
       << ";    command = value" << endl
       << ";" << endl
-      << ";  Commmands are the same as those specified on the commandline," << endl
+      << ";  Commands are the same as those specified on the commandline," << endl
       << ";  without the '-' character." << endl
       << ";" << endl
       << ";  Values are the same as those allowed on the commandline." << endl


### PR DESCRIPTION
* commmands -> commands
* comparitive -> comparative

These were found by Debian’s Lintian tool.

Signed-off-by: Stephen Kitt <steve@sk2.org>