### PR TITLE
Add debugger commands to manipulate controller state.

### DIFF
--- a/src/debugger/DebuggerParser.cxx
+++ b/src/debugger/DebuggerParser.cxx
@@ -1500,6 +1500,16 @@ void DebuggerParser::executeReset()
 {
   debugger.reset();
   debugger.rom().invalidate();
+  debugger.riotDebug().controller(Controller::Left).set(Controller::One, true);
+  debugger.riotDebug().controller(Controller::Left).set(Controller::Two, true);
+  debugger.riotDebug().controller(Controller::Left).set(Controller::Three, true);
+  debugger.riotDebug().controller(Controller::Left).set(Controller::Four, true);
+  debugger.riotDebug().controller(Controller::Left).set(Controller::Six, true);
+  debugger.riotDebug().controller(Controller::Right).set(Controller::One, true);
+  debugger.riotDebug().controller(Controller::Right).set(Controller::Two, true);
+  debugger.riotDebug().controller(Controller::Right).set(Controller::Three, true);
+  debugger.riotDebug().controller(Controller::Right).set(Controller::Four, true);
+  debugger.riotDebug().controller(Controller::Right).set(Controller::Six, true);
   commandResult << "reset system";
 }
 

--- a/src/debugger/DebuggerParser.cxx
+++ b/src/debugger/DebuggerParser.cxx
@@ -1162,6 +1162,116 @@ void DebuggerParser::executeHelp()
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy0up"
+void DebuggerParser::executeJoy0Up()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Left);
+  if(argCount == 0)
+    controller.set(Controller::One, !controller.read(Controller::One));
+  else if(argCount == 1)
+    controller.set(Controller::One, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy0down"
+void DebuggerParser::executeJoy0Down()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Left);
+  if(argCount == 0)
+    controller.set(Controller::Two, !controller.read(Controller::Two));
+  else if(argCount == 1)
+    controller.set(Controller::Two, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy0left"
+void DebuggerParser::executeJoy0Left()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Left);
+  if(argCount == 0)
+    controller.set(Controller::Three, !controller.read(Controller::Three));
+  else if(argCount == 1)
+    controller.set(Controller::Three, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy0right"
+void DebuggerParser::executeJoy0Right()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Left);
+  if(argCount == 0)
+    controller.set(Controller::Four, !controller.read(Controller::Four));
+  else if(argCount == 1)
+    controller.set(Controller::Four, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy0fire"
+void DebuggerParser::executeJoy0Fire()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Left);
+  if(argCount == 0)
+    controller.set(Controller::Six, !controller.read(Controller::Six));
+  else if(argCount == 1)
+    controller.set(Controller::Six, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy1up"
+void DebuggerParser::executeJoy1Up()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Right);
+  if(argCount == 0)
+    controller.set(Controller::One, !controller.read(Controller::One));
+  else if(argCount == 1)
+    controller.set(Controller::One, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy1down"
+void DebuggerParser::executeJoy1Down()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Right);
+  if(argCount == 0)
+    controller.set(Controller::Two, !controller.read(Controller::Two));
+  else if(argCount == 1)
+    controller.set(Controller::Two, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy1left"
+void DebuggerParser::executeJoy1Left()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Right);
+  if(argCount == 0)
+    controller.set(Controller::Three, !controller.read(Controller::Three));
+  else if(argCount == 1)
+    controller.set(Controller::Three, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy1right"
+void DebuggerParser::executeJoy1Right()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Right);
+  if(argCount == 0)
+    controller.set(Controller::Four, !controller.read(Controller::Four));
+  else if(argCount == 1)
+    controller.set(Controller::Four, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "joy1fire"
+void DebuggerParser::executeJoy1Fire()
+{
+  Controller& controller = debugger.riotDebug().controller(Controller::Right);
+  if(argCount == 0)
+    controller.set(Controller::Six, !controller.read(Controller::Six));
+  else if(argCount == 1)
+    controller.set(Controller::Six, args[0] != 0);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // "jump"
 void DebuggerParser::executeJump()
 {
@@ -2303,6 +2413,106 @@ DebuggerParser::Command DebuggerParser::commands[kNumCommands] = {
     false,
     { kARG_LABEL, kARG_END_ARGS },
     std::mem_fn(&DebuggerParser::executeHelp)
+  },
+
+  {
+    "joy0up",
+    "Set joystick 0 up direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy0up 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy0Up)
+  },
+
+  {
+    "joy0down",
+    "Set joystick 0 down direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy0down 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy0Down)
+  },
+
+  {
+    "joy0left",
+    "Set joystick 0 left direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy0left 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy0Left)
+  },
+
+  {
+    "joy0right",
+    "Set joystick 0 right direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy0left 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy0Right)
+  },
+
+  {
+    "joy0fire",
+    "Set joystick 0 fire button to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy0fire 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy0Fire)
+  },
+
+  {
+    "joy1up",
+    "Set joystick 1 up direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy1up 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy1Up)
+  },
+
+  {
+    "joy1down",
+    "Set joystick 1 down direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy1down 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy1Down)
+  },
+
+  {
+    "joy1left",
+    "Set joystick 1 left direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy1left 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy1Left)
+  },
+
+  {
+    "joy1right",
+    "Set joystick 1 right direction to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy1left 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy1Right)
+  },
+
+  {
+    "joy1fire",
+    "Set joystick 1 fire button to value <x> (0 or 1), or toggle (no arg)",
+    "Example: joy1fire 0",
+    false,
+    true,
+    { kARG_BOOL, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeJoy1Fire)
   },
 
   {

--- a/src/debugger/DebuggerParser.cxx
+++ b/src/debugger/DebuggerParser.cxx
@@ -1064,7 +1064,10 @@ void DebuggerParser::executeExec()
   if(file.find_last_of('.') == string::npos)
     file += ".script";
 
-  FilesystemNode node(debugger.myOSystem.defaultSaveDir() + file);
+  FilesystemNode node(file);
+  if (!node.exists()) {
+    node = FilesystemNode(debugger.myOSystem.defaultSaveDir() + file);
+  }
   execDepth++;
   commandResult << exec(node);
   execDepth--;

--- a/src/debugger/DebuggerParser.cxx
+++ b/src/debugger/DebuggerParser.cxx
@@ -1767,6 +1767,23 @@ void DebuggerParser::executeStep()
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// "stepwhile"
+void DebuggerParser::executeStepwhile()
+{
+  int res = YaccParser::parse(argStrings[0].c_str());
+  if(res != 0) {
+    commandResult << red("invalid expression");
+    return;
+  }
+  Expression* expr = YaccParser::getResult();
+  int ncycles = 0;
+  do {
+    ncycles += debugger.step();
+  } while (expr->evaluate());
+  commandResult << "executed " << ncycles << " cycles";
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // "tia"
 void DebuggerParser::executeTia()
 {
@@ -2866,6 +2883,16 @@ DebuggerParser::Command DebuggerParser::commands[kNumCommands] = {
     true,
     { kARG_WORD, kARG_END_ARGS },
     std::mem_fn(&DebuggerParser::executeStep)
+  },
+
+  {
+    "stepwhile",
+    "Single step CPU while <condition> is true",
+    "Example: stepwhile pc!=$f2a9",
+    true,
+    true,
+    { kARG_WORD, kARG_END_ARGS },
+    std::mem_fn(&DebuggerParser::executeStepwhile)
   },
 
   {

--- a/src/debugger/DebuggerParser.cxx
+++ b/src/debugger/DebuggerParser.cxx
@@ -58,7 +58,8 @@ using std::right;
 DebuggerParser::DebuggerParser(Debugger& d, Settings& s)
   : debugger(d),
     settings(s),
-    argCount(0)
+    argCount(0),
+    execDepth(0)
 {
 }
 
@@ -1064,7 +1065,9 @@ void DebuggerParser::executeExec()
     file += ".script";
 
   FilesystemNode node(debugger.myOSystem.defaultSaveDir() + file);
+  execDepth++;
   commandResult << exec(node);
+  execDepth--;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1695,7 +1698,7 @@ void DebuggerParser::executeSaveses()
 // "savesnap"
 void DebuggerParser::executeSavesnap()
 {
-  debugger.tiaOutput().saveSnapshot();
+  debugger.tiaOutput().saveSnapshot(execDepth);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/debugger/DebuggerParser.cxx
+++ b/src/debugger/DebuggerParser.cxx
@@ -59,7 +59,8 @@ DebuggerParser::DebuggerParser(Debugger& d, Settings& s)
   : debugger(d),
     settings(s),
     argCount(0),
-    execDepth(0)
+    execDepth(0),
+    execPrefix("")
 {
 }
 
@@ -1063,10 +1064,18 @@ void DebuggerParser::executeExec()
   string file = argStrings[0];
   if(file.find_last_of('.') == string::npos)
     file += ".script";
-
   FilesystemNode node(file);
   if (!node.exists()) {
     node = FilesystemNode(debugger.myOSystem.defaultSaveDir() + file);
+  }
+
+  if (argCount == 2) {
+    execPrefix = argStrings[1];
+  }
+  else {
+    ostringstream prefix;
+    prefix << std::hex << std::setw(8) << std::setfill('0') << (debugger.myOSystem.getTicks()/1000 & 0xffffffff);
+    execPrefix = prefix.str();
   }
   execDepth++;
   commandResult << exec(node);
@@ -1711,7 +1720,7 @@ void DebuggerParser::executeSaveses()
 // "savesnap"
 void DebuggerParser::executeSavesnap()
 {
-  debugger.tiaOutput().saveSnapshot(execDepth);
+  debugger.tiaOutput().saveSnapshot(execDepth, execPrefix);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2389,11 +2398,11 @@ DebuggerParser::Command DebuggerParser::commands[kNumCommands] = {
 
   {
     "exec",
-    "Execute script file <xx>",
+    "Execute script file <xx> [prefix]",
     "Example: exec script.dat, exec auto.txt",
     true,
     true,
-    { kARG_FILE, kARG_END_ARGS },
+    { kARG_FILE, kARG_LABEL, kARG_MULTI_BYTE },
     std::mem_fn(&DebuggerParser::executeExec)
   },
 

--- a/src/debugger/DebuggerParser.hxx
+++ b/src/debugger/DebuggerParser.hxx
@@ -124,6 +124,7 @@ class DebuggerParser
     uInt32 argCount;
 
     uInt32 execDepth;
+    string execPrefix;
 
     StringList myWatches;
 

--- a/src/debugger/DebuggerParser.hxx
+++ b/src/debugger/DebuggerParser.hxx
@@ -123,6 +123,8 @@ class DebuggerParser
     StringList argStrings;
     uInt32 argCount;
 
+    uInt32 execDepth;
+
     StringList myWatches;
 
     // Keep track of traps (read and/or write)

--- a/src/debugger/DebuggerParser.hxx
+++ b/src/debugger/DebuggerParser.hxx
@@ -66,7 +66,7 @@ class DebuggerParser
     string saveScriptFile(string file);
 
   private:
-    enum { kNumCommands = 91 };
+    enum { kNumCommands = 92 };
 
     // Constants for argument processing
     enum {
@@ -210,6 +210,7 @@ class DebuggerParser
     void executeSavestateif();
     void executeScanline();
     void executeStep();
+    void executeStepwhile();
     void executeTia();
     void executeTrace();
     void executeTrap();

--- a/src/debugger/DebuggerParser.hxx
+++ b/src/debugger/DebuggerParser.hxx
@@ -66,7 +66,7 @@ class DebuggerParser
     string saveScriptFile(string file);
 
   private:
-    enum { kNumCommands = 81 };
+    enum { kNumCommands = 91 };
 
     // Constants for argument processing
     enum {
@@ -165,6 +165,16 @@ class DebuggerParser
     void executeFunction();
     void executeGfx();
     void executeHelp();
+    void executeJoy0Up();
+    void executeJoy0Down();
+    void executeJoy0Left();
+    void executeJoy0Right();
+    void executeJoy0Fire();
+    void executeJoy1Up();
+    void executeJoy1Down();
+    void executeJoy1Left();
+    void executeJoy1Right();
+    void executeJoy1Fire();
     void executeJump();
     void executeListbreaks();
     void executeListconfig();

--- a/src/debugger/gui/TiaOutputWidget.cxx
+++ b/src/debugger/gui/TiaOutputWidget.cxx
@@ -63,7 +63,6 @@ void TiaOutputWidget::saveSnapshot(int execDepth, const string& execPrefix)
   if (execDepth > 0) {
     drawWidget(false);
   }
-  int number = int(instance().getTicks() / 1000);
   ostringstream sspath;
   sspath << instance().snapshotSaveDir()
          << instance().console().properties().get(Cartridge_Name);
@@ -71,7 +70,7 @@ void TiaOutputWidget::saveSnapshot(int execDepth, const string& execPrefix)
   if (execDepth > 0 && !execPrefix.empty()) {
     sspath << execPrefix << "_";
   }
-  sspath << std::hex << std::setw(8) << std::setfill('0') << (number/1000 & 0xffffffff) << ".png";
+  sspath << std::hex << std::setw(8) << std::setfill('0') << (instance().getTicks()/1000 & 0xffffffff) << ".png";
 
   const uInt32 width  = instance().console().tia().width(),
                height = instance().console().tia().height();

--- a/src/debugger/gui/TiaOutputWidget.cxx
+++ b/src/debugger/gui/TiaOutputWidget.cxx
@@ -58,8 +58,11 @@ void TiaOutputWidget::loadConfig()
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void TiaOutputWidget::saveSnapshot()
+void TiaOutputWidget::saveSnapshot(int execDepth)
 {
+  if (execDepth > 0) {
+    drawWidget(false);
+  }
   int number = int(instance().getTicks() / 1000);
   ostringstream sspath;
   sspath << instance().snapshotSaveDir()
@@ -80,7 +83,9 @@ void TiaOutputWidget::saveSnapshot()
   {
     message = e.what();
   }
-  instance().frameBuffer().showMessage(message);
+  if (execDepth == 0) {
+    instance().frameBuffer().showMessage(message);
+  }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/debugger/gui/TiaOutputWidget.cxx
+++ b/src/debugger/gui/TiaOutputWidget.cxx
@@ -58,7 +58,7 @@ void TiaOutputWidget::loadConfig()
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void TiaOutputWidget::saveSnapshot(int execDepth)
+void TiaOutputWidget::saveSnapshot(int execDepth, const string& execPrefix)
 {
   if (execDepth > 0) {
     drawWidget(false);
@@ -66,8 +66,12 @@ void TiaOutputWidget::saveSnapshot(int execDepth)
   int number = int(instance().getTicks() / 1000);
   ostringstream sspath;
   sspath << instance().snapshotSaveDir()
-         << instance().console().properties().get(Cartridge_Name)
-         << "_dbg_" << std::hex << std::setw(8) << std::setfill('0') << number << ".png";
+         << instance().console().properties().get(Cartridge_Name);
+  sspath << "_dbg_";
+  if (execDepth > 0 && !execPrefix.empty()) {
+    sspath << execPrefix << "_";
+  }
+  sspath << std::hex << std::setw(8) << std::setfill('0') << (number/1000 & 0xffffffff) << ".png";
 
   const uInt32 width  = instance().console().tia().width(),
                height = instance().console().tia().height();

--- a/src/debugger/gui/TiaOutputWidget.hxx
+++ b/src/debugger/gui/TiaOutputWidget.hxx
@@ -36,7 +36,8 @@ class TiaOutputWidget : public Widget, public CommandSender
     void loadConfig() override;
     void setZoomWidget(TiaZoomWidget* w) { myZoom = w; }
 
-    void saveSnapshot();
+    void saveSnapshot() { saveSnapshot(0); };
+    void saveSnapshot(int execDepth);
 
 // Eventually, these methods will enable access to the onscreen TIA image
 // For example, clicking an area may cause an action

--- a/src/debugger/gui/TiaOutputWidget.hxx
+++ b/src/debugger/gui/TiaOutputWidget.hxx
@@ -36,8 +36,8 @@ class TiaOutputWidget : public Widget, public CommandSender
     void loadConfig() override;
     void setZoomWidget(TiaZoomWidget* w) { myZoom = w; }
 
-    void saveSnapshot() { saveSnapshot(0); };
-    void saveSnapshot(int execDepth);
+    void saveSnapshot() { saveSnapshot(0, ""); };
+    void saveSnapshot(int execDepth, const string& execPrefix);
 
 // Eventually, these methods will enable access to the onscreen TIA image
 // For example, clicking an area may cause an action


### PR DESCRIPTION
This pull request adds 10 new debugger commands to manipulate programmatically the state of the controller inputs. These commands are supposed to be used from debugger scripts (using `exec`). The names of the commands are similar to the built-in debugger functions.