### PR TITLE
Desired desktop resolution minus dock for Mac OS X (requires SDL-2.0.…

### DIFF
--- a/src/common/FrameBufferSDL2.cxx
+++ b/src/common/FrameBufferSDL2.cxx
@@ -76,14 +76,24 @@ void FrameBufferSDL2::queryHardware(vector<GUI::Size>& displays,
                                     VariantList& renderers)
 {
   // First get the maximum windowed desktop resolution
-  SDL_DisplayMode display;
   int maxDisplays = SDL_GetNumVideoDisplays();
+#if 0 //def BSPF_MAC_OSX
+  SDL_Rect r;
+  for(int i = 0; i < maxDisplays; ++i)
+  {
+    // Display bounds minus dock
+    SDL_GetDisplayUsableBounds(i, &r);   // Requires SDL-2.0.5 or higher
+    displays.emplace_back(r.w, r.h);
+  }
+#else
+  SDL_DisplayMode display;
   for(int i = 0; i < maxDisplays; ++i)
   {
     SDL_GetDesktopDisplayMode(i, &display);
     displays.emplace_back(display.w, display.h);
   }
-
+#endif
+  
   struct RenderName
   {
     string sdlName;


### PR DESCRIPTION
…5 or higher)

I suggest to update to SDL-2.0.8 because it allows to get desktop resolution minus dock in Mac OS X. I found highly annoying to have to disable dock each time in order to see the bottom of debugger when in windowed mode