### PR TITLE
Clean up all initialized SDL subsystems on the way out

### DIFF
--- a/src/common/FrameBufferSDL2.cxx
+++ b/src/common/FrameBufferSDL2.cxx
@@ -72,6 +72,7 @@ FrameBufferSDL2::~FrameBufferSDL2()
     SDL_DestroyWindow(myWindow);
     myWindow = nullptr;
   }
+  SDL_Quit();
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
The initial call to SDL_Init() is supposed to be paired with a call to SDL_Quit(). I was experimenting with Stella linked against SDL 2.0.8, running in the console-framebuffer mode on Raspbian Stretch Lite, and I ended up reproducing issue #281 on a Raspberry Pi 3.

This one-line change seems to have fixed that problem.

(While this change doesn't make the framebuffer experience completely perfect, it is at least pretty good and _very_ fast, and it's also no longer disastrous.)