### PR TITLE
Rename PAGE_SIZE

### DIFF
--- a/src/common/bspf.hxx
+++ b/src/common/bspf.hxx
@@ -87,6 +87,8 @@ using BytePtr = std::unique_ptr<uInt8[]>;
 
 static const string EmptyString("");
 
+#undef PAGE_SIZE
+
 namespace BSPF
 {
   // Defines to help with path handling


### PR DESCRIPTION
PAGE_SIZE is sometimes already defined by the toolchain so rename it:

/home/naourr/work/instance-3/output/host/bin/x86_64-linux-g++ -MMD -MF "src/debugger/.deps/CpuDebug.d" -MQ "src/debugger/CpuDebug.o" -MP -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -x c++ -Wall -Wextra -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-multichar -Wunused -fno-rtti -Woverloaded-virtual -Wnon-virtual-dtor -std=c++14 -fomit-frame-pointer -D_GLIBCXX_USE_CXX11_ABI=1 -DUNIX -DBSPF_UNIX -DWINDOWED_SUPPORT -DSOUND_SUPPORT -DDEBUGGER_SUPPORT -DJOYSTICK_SUPPORT -DCHEATCODE_SUPPORT  -Isrc/emucore -Isrc/common -Isrc/common/tv_filters -Isrc/gui -Isrc/emucore/tia -Isrc/emucore/tia/frame-manager -I/home/naourr/work/instance-3/output/host/x86_64-buildroot-linux-musl/sysroot/usr/bin/../../usr/include/SDL2 -D_REENTRANT -Isrc/unix -Isrc/debugger -Isrc/debugger/gui -Isrc/yacc -Isrc/cheat -c src/debugger/CpuDebug.cxx -o src/debugger/CpuDebug.o
In file included from /home/naourr/work/instance-3/output/host/x86_64-buildroot-linux-musl/sysroot/usr/include/limits.h:8:0,
                 from /home/naourr/work/instance-3/output/host/opt/ext-toolchain/x86_64-buildroot-linux-musl/include/c++/7.4.0/climits:42,
                 from src/common/bspf.hxx:28,
                 from src/debugger/CartDebug.cxx:18:
src/emucore/System.hxx:64:29: error: expected unqualified-id before numeric constant
     static constexpr uInt16 PAGE_SIZE = (1 << PAGE_SHIFT);

Fixes:
 - http://autobuild.buildroot.org/results/22a9b009749af2a0862750a1fb2b2dc7167cd589

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>