### PR TITLE
Update .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 config.log
 config.mak
 src/**/*/.deps
+src/**/*.so
+src/**/*.dylib
+src/**/*.dll
 src/**/*.o
 out
 out.pgo


### PR DESCRIPTION
This avoids commiting libretro cores accidentally.