### PR TITLE
libretro: Another fix for msvc.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -10,11 +10,11 @@ BACKSLASH := \$(BACKSLASH)
 filter_out1 = $(filter-out $(firstword $1),$1)
 filter_out2 = $(call filter_out1,$(call filter_out1,$1))
 
-CXXFLAGS+= -Wall -Wno-unused-parameter -Wno-ignored-qualifiers
+CXXFLAGS+= -Wall -Wno-ignored-qualifiers
 CXXFLAGS+= -Wno-multichar -Wunused -fno-rtti -Woverloaded-virtual -Wnon-virtual-dtor -std=c++14
 
 ifeq (,$(findstring msvc,$(platform)))
-   CXXFLAGS+= -Wextra
+   CXXFLAGS+= -Wextra -Wno-unused-parameter
 endif
 
 ifeq ($(platform),)


### PR DESCRIPTION
Seems the last fix for moving `-Wextra` worked, but now its stuck on `-Wno-unused-parameter` instead. This might take a few attempts...
```
make: *** [Makefile:656: ../libretro/libretro.o] Error 2
cl : Command line error D8021 : cl : Command line error D8021 : cl : Command line error D8021 : cl : Command line error D8021 : invalid numeric argument '/Wno-unused-parameter'invalid numeric argument '/Wno-unused-parameter'invalid numeric argument '/Wno-unused-parameter'invalid numeric argument '/Wno-unused-parameter'
```