### PR TITLE
libretro: Fix linux build.

### DIFF
--- a/src/libretro/Makefile.common
+++ b/src/libretro/Makefile.common
@@ -19,6 +19,7 @@ SOURCES_CXX := \
 	$(CORE_DIR)/common/Base.cxx \
 	$(CORE_DIR)/common/FpsMeter.cxx \
 	$(CORE_DIR)/common/FSNodeZIP.cxx \
+	$(CORE_DIR)/common/Logger.cxx \
 	$(CORE_DIR)/common/MouseControl.cxx \
 	$(CORE_DIR)/common/PhysicalJoystick.cxx \
 	$(CORE_DIR)/common/PJoystickHandler.cxx \


### PR DESCRIPTION
It now builds here again with 64-bit linux.

See: 

https://github.com/stella-emu/stella/issues/377#issuecomment-488553546
https://github.com/stella-emu/stella/commit/d8f28f19cee08f5c00dc306fae6a5072054030f9