### PR TITLE
libretro: Remove unused include paths.

### DIFF
--- a/src/libretro/Makefile.common
+++ b/src/libretro/Makefile.common
@@ -1,5 +1,5 @@
 LIBRETRO_COMM_DIR = $(CORE_DIR)/../libretro-common
-INCFLAGS := -I. -I$(CORE_DIR) -I$(CORE_DIR)/libretro -I$(CORE_DIR)/libretro/SDL -I$(CORE_DIR)/libretro/libpng -I$(CORE_DIR)/libretro/zlib -I$(CORE_DIR)/emucore -I$(CORE_DIR)/emucore/tia -I$(CORE_DIR)/common -I$(CORE_DIR)/common/audio -I$(CORE_DIR)/common/tv_filters -I$(CORE_DIR)/gui
+INCFLAGS := -I. -I$(CORE_DIR) -I$(CORE_DIR)/libretro -I$(CORE_DIR)/emucore -I$(CORE_DIR)/emucore/tia -I$(CORE_DIR)/common -I$(CORE_DIR)/common/audio -I$(CORE_DIR)/common/tv_filters -I$(CORE_DIR)/gui
 
 ifneq (,$(findstring msvc2003,$(platform)))
 INCFLAGS += -I$(LIBRETRO_COMM_DIR)/include/compat/msvc


### PR DESCRIPTION
This removes `-I../libretro/SDL`, `-I../libretro/libpng` and `-I../libretro/zlib` from libretro's `Makefile.common`. I don't think the libretro core uses these anymore and the paths are not valid. It builds without issue here on linux at least.