### PR TITLE
libretro: Attempted fix for osx.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -88,7 +88,7 @@ ifneq (,$(findstring unix,$(platform)))
 else ifeq ($(platform), osx)
    CFLAGS += $(LTO) $(PTHREAD_FLAGS)
    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS)
-   LDFLAGS += $(LTO) $(PTHREAD_FLAGS)
+   LDFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC
    SHARED := -dynamiclib


### PR DESCRIPTION
This an attempted fix for the osx buildbot, I notice the standalone stella already seems to use this for osx.

Reference: https://stackoverflow.com/questions/10116724/clang-os-x-lion-cannot-find-cstdint/10116753#10116753

Note I think this will only work with clang, but I understand that is already advisable on osx with stella and the libretro buildbot is already using clang. Some other libretro makefiles seem to be doing this for osx as well.
```
In file included from ../libretro/EventHandlerLIBRETRO.cxx:18:
../emucore/OSystem.hxx:45:10: fatal error: 'chrono' file not found
#include <chrono>
         ^
In file included from ../libretro/libretro.cxx:15:
In file included from ./StellaLIBRETRO.hxx:21:
../common/bspf.hxx:29:10: fatal error: 'cstdint' file not found
#include <cstdint>
         ^
1 error generated.
make: *** [../libretro/EventHandlerLIBRETRO.o] Error 1
```