### PR TITLE
libretro: Try setting osx to 10.7.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -102,8 +102,8 @@ else ifeq ($(platform), osx)
    OSXVER = $(shell sw_vers -productVersion | cut -d. -f 2)
    OSX_GT_MOJAVE = $(shell (( $(OSXVER) >= 14)) && echo "YES")
    ifneq ($(OSX_GT_MOJAVE),YES)
-	#this breaks compiling on Mac OS Mojave
-      fpic += -mmacosx-version-min=10.1
+      #this breaks compiling on Mac OS Mojave
+      fpic += -mmacosx-version-min=10.7
    endif
 
 # Nintendo Switch (libnx)


### PR DESCRIPTION
The last build from the libretro buildbot had a new issue as a result to my previous PR (https://github.com/stella-emu/stella/pull/449).
```
clang: error: invalid deployment target for -stdlib=libc++ (requires OS X 10.7 or later)
clang: error: invalid deployment target for -stdlib=libc++ (requires OS X 10.7 or later)
make: *** [../libretro/EventHandlerLIBRETRO.o] Error 1
```
It was suggested in #libretro @ freenode by Twinaphex to try setting this line to `10.7`. Hopefully this will help.