### PR TITLE
libretro: Remove CFLAGS and CC from the Makefile.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -61,16 +61,15 @@ endif
 
 # Unix
 ifneq (,$(findstring unix,$(platform)))
-   CFLAGS += $(LTO) $(PTHREAD_FLAGS)
    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS)
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    ifneq ($(findstring SunOS,$(shell uname -a)),)
-   CC = gcc
-   SHARED := -shared -z defs
+      CXX = g++
+      SHARED := -shared -z defs
    else
-   SHARED := -shared -Wl,--version-script=link.T -Wl,-z,defs
+      SHARED := -shared -Wl,--version-script=link.T -Wl,-z,defs
    endif
    ifneq ($(findstring Haiku,$(shell uname -a)),)
       LIBS :=
@@ -86,7 +85,6 @@ ifneq (,$(findstring unix,$(platform)))
 
 # OS X
 else ifeq ($(platform), osx)
-   CFLAGS += $(LTO) $(PTHREAD_FLAGS)
    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS)
    TARGET := $(TARGET_NAME)_libretro.dylib
@@ -111,9 +109,8 @@ else ifeq ($(platform), libnx)
    include $(DEVKITPRO)/libnx/switch_rules
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    DEFINES := -DSWITCH=1 -D__SWITCH__ -DARM
-   CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec -specs=$(LIBNX)/switch.specs
-   CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math
-   CXXFLAGS := $(ASFLAGS) $(CFLAGS)
+   CXXFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec -specs=$(LIBNX)/switch.specs
+   CXXFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math $(ASFLAGS)
    STATIC_LINKING = 1
 
 # Classic Platforms ####################
@@ -134,17 +131,16 @@ else ifeq ($(platform), classic_armv7_a7)
 	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
 	-fmerge-all-constants -fno-math-errno \
 	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-	CFLAGS += $(CXXFLAGS)
 	HAVE_NEON = 1
 	ARCH = arm
 	BUILTIN_GPU = neon
 	USE_DYNAREC = 1
-	ifeq ($(shell echo `$(CC) -dumpversion` "< 4.9" | bc -l), 1)
-	  CFLAGS += -march=armv7-a
+	ifeq ($(shell echo `$(CXX) -dumpversion` "< 4.9" | bc -l), 1)
+	  CXXFLAGS += -march=armv7-a
 	else
-	  CFLAGS += -march=armv7ve
+	  CXXFLAGS += -march=armv7ve
 	  # If gcc is 5.0 or later
-	  ifeq ($(shell echo `$(CC) -dumpversion` ">= 5" | bc -l), 1)
+	  ifeq ($(shell echo `$(CXX) -dumpversion` ">= 5" | bc -l), 1)
 	    LDFLAGS += -static-libgcc -static-libstdc++
 	  endif
 	endif
@@ -152,7 +148,6 @@ else ifeq ($(platform), classic_armv7_a7)
 
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
-   CFLAGS += $(LTO) $(PTHREAD_FLAGS)
    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS)
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS)
    TARGET := $(TARGET_NAME)_libretro_ios.dylib
@@ -162,29 +157,22 @@ else ifneq (,$(findstring ios,$(platform)))
       IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
    endif
    ifeq ($(platform),ios-arm64)
-		CC = clang -arch arm64 -isysroot $(IOSSDK)
 		CXX = clang++ -arch arm64 -isysroot $(IOSSDK)
    else
-		CC = clang -arch armv7 -isysroot $(IOSSDK)
 		CXX = clang++ -arch armv7 -isysroot $(IOSSDK)
    endif
    CXXFLAGS += -DIOS
    CXXFLAGS += -DARM
    ifeq ($(platform),$(filter $(platform),ios9 ios-arm64))
-      CC       += -miphoneos-version-min=8.0
       CXX      += -miphoneos-version-min=8.0
-      CFLAGS   += -miphoneos-version-min=8.0
       CXXFLAGS += -miphoneos-version-min=8.0
    else
-      CC       += -miphoneos-version-min=5.0
       CXX      += -miphoneos-version-min=5.0
-      CFLAGS   += -miphoneos-version-min=5.0
       CXXFLAGS += -miphoneos-version-min=5.0
    endif
 
 # Theos
 else ifeq ($(platform), theos_ios)
-   CFLAGS += $(LTO)
    CXXFLAGS += $(LTO)
    LDFLAGS += $(LTO)
    DEPLOYMENT_IOSVERSION = 5.0
@@ -200,7 +188,6 @@ else ifeq ($(platform), qnx)
    TARGET := $(TARGET_NAME)_libretro_$(platform).so
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=link.T
-   CC = qcc -Vgcc_notarmv7le
    CXX = QCC -Vgcc_notarmv7le
    AR = QCC -Vgcc_ntoarmv7le
    CXXFLAGS += -D__BLACKBERRY_QNX__
@@ -209,12 +196,10 @@ else ifeq ($(platform), qnx)
 
 # Vita
 else ifeq ($(platform), vita)
-   CFLAGS += $(LTO)
    CXXFLAGS += $(LTO)
    LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro_$(platform).so
    fpic := -fPIC
-   CC = arm-vita-eabi-gcc$(EXE_EXT)
    CXX = arm-vita-eabi-g++$(EXE_EXT)
    AR = arm-vita-eabi-ar$(EXE_EXT)
    CXXFLAGS += -DVITA
@@ -230,30 +215,25 @@ else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
    # sncps3
    ifneq (,$(findstring sncps3,$(platform)))
       TARGET := $(TARGET_NAME)_libretro_ps3.a
-      CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-      CXX = $(CC)
+      CXX = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
       AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
 
    # PS3
    else ifneq (,$(findstring ps3,$(platform)))
-      CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
       CXX = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-g++.exe
       AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
 
    # Lightweight PS3 Homebrew SDK
    else ifneq (,$(findstring psl1ght,$(platform)))
-      CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
       CXX = $(PS3DEV)/ppu/bin/ppu-g++$(EXE_EXT)
       AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
    endif
 
 # Xbox 360
 else ifeq ($(platform), xenon)
-   CFLAGS += $(LTO)
    CXXFLAGS += $(LTO)
    LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro_xenon360.a
-   CC = xenon-gcc$(EXE_EXT)
    CXX = xenon-g++$(EXE_EXT)
    AR = xenon-ar$(EXE_EXT)
    CXXFLAGS += -D__LIBXENON__ -m32 -D__ppc__
@@ -263,7 +243,6 @@ else ifeq ($(platform), xenon)
 # Nintendo Game Cube / Wii / WiiU
 else ifneq (,$(filter $(platform), ngc wii wiiu))
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
-   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    CXXFLAGS += -mcpu=750 -meabi -mhard-float -DBLARGG_BIG_ENDIAN=1 -D__ppc__
@@ -288,7 +267,6 @@ else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
    CXXFLAGS += $(PTHREAD_FLAGS) -std=c++14
-   CFLAGS += $(PTHREAD_FLAGS)
    LDFLAGS += $(PTHREAD_FLAGS) -std=c++14
 
 # Genode
@@ -301,7 +279,6 @@ else ifeq ($(platform), genode)
    LDFLAGS += -shared --version-script=link.T
    LDFLAGS += $(shell pkg-config --libs $(PKG_CONFIG))
 
-   CC  = $(shell pkg-config genode-base --variable=cc)
    CXX = $(shell pkg-config genode-base --variable=cxx)
    LD  = $(shell pkg-config genode-base --variable=ld)
    AR  = $(shell pkg-config genode-base --variable=ar) -rcs
@@ -309,42 +286,35 @@ else ifeq ($(platform), genode)
 
 # Windows MSVC 2003 Xbox 1
 else ifeq ($(platform), xbox1_msvc2003)
-CFLAGS += -D__WIN32__
 CXXFLAGS += -D__WIN32__
 TARGET := $(TARGET_NAME)_libretro_xdk1.lib
 MSVCBINDIRPREFIX = $(XDK)/xbox/bin/vc71
-CC  = "$(MSVCBINDIRPREFIX)/CL.exe"
 CXX  = "$(MSVCBINDIRPREFIX)/CL.exe"
 LD   = "$(MSVCBINDIRPREFIX)/lib.exe"
 
 export INCLUDE := $(XDK)/xbox/include
 export LIB := $(XDK)/xbox/lib
 PSS_STYLE :=2
-CFLAGS   += -D_XBOX -D_XBOX1
 CXXFLAGS += -D_XBOX -D_XBOX1
 STATIC_LINKING=1
 HAS_GCC := 0
 # Windows MSVC 2010 Xbox 360
 else ifeq ($(platform), xbox360_msvc2010)
-CFLAGS += -D__WIN32__
 CXXFLAGS += -D__WIN32__
 TARGET := $(TARGET_NAME)_libretro_xdk360.lib
 MSVCBINDIRPREFIX = $(XEDK)/bin/win32
-CC  = "$(MSVCBINDIRPREFIX)/cl.exe"
 CXX  = "$(MSVCBINDIRPREFIX)/cl.exe"
 LD   = "$(MSVCBINDIRPREFIX)/lib.exe"
 
 export INCLUDE := $(XEDK)/include/xbox
 export LIB := $(XEDK)/lib/xbox
 PSS_STYLE :=2
-CFLAGS   += -D_XBOX -D_XBOX360
 CXXFLAGS += -D_XBOX -D_XBOX360
 STATIC_LINKING=1
 HAS_GCC := 0
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))
-    CFLAGS += -D__WIN32__
     CXXFLAGS += -D__WIN32__
 
 	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
@@ -363,12 +333,10 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	# Specific to this core
 	MSVC2017CompileFlags += -D__WIN32__ /std:c++17
 
-	CFLAGS += $(MSVC2017CompileFlags)
 	CXXFLAGS += $(MSVC2017CompileFlags)
 
 	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
 
-	CC  = cl.exe
 	CXX = cl.exe
 
 	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
@@ -438,10 +406,8 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)
-    CFLAGS += -D__WIN32__
-    CXXFLAGS += -D__WIN32__
-	CC  = cl.exe
-	CXX = cl.exe
+   CXXFLAGS += -D__WIN32__
+   CXX = cl.exe
 
 PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin/amd64"):$(PATH)
 PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
@@ -464,10 +430,8 @@ LDFLAGS += -DLL
 LIBS :=
 # Windows MSVC 2010 x86
 else ifeq ($(platform), windows_msvc2010_x86)
-    CFLAGS += -D__WIN32__
-    CXXFLAGS += -D__WIN32__
-	CC  = cl.exe
-	CXX = cl.exe
+   CXXFLAGS += -D__WIN32__
+   CXX = cl.exe
 
 PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin"):$(PATH)
 PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
@@ -491,10 +455,8 @@ LIBS :=
 
 # Windows MSVC 2003 x86
 else ifeq ($(platform), windows_msvc2003_x86)
-    CFLAGS += -D__WIN32__
-    CXXFLAGS += -D__WIN32__
-	CC  = cl.exe
-	CXX = cl.exe
+   CXXFLAGS += -D__WIN32__
+   CXX = cl.exe
 
 PATH := $(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../../Vc7/bin"):$(PATH)
 PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../IDE")
@@ -509,14 +471,12 @@ export LIB := $(LIB);$(WindowsSdkDir);$(INETSDK)/Lib
 TARGET := $(TARGET_NAME)_libretro.dll
 PSS_STYLE :=2
 LDFLAGS += -DLL
-CFLAGS += -D_CRT_SECURE_NO_DEPRECATE
+CXXFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 
 # Windows MSVC 2005 x86
 else ifeq ($(platform), windows_msvc2005_x86)
-    CFLAGS += -D__WIN32__
-    CXXFLAGS += -D__WIN32__
-	CC  = cl.exe
-	CXX = cl.exe
+   CXXFLAGS += -D__WIN32__
+   CXX = cl.exe
 
 PATH := $(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../../VC/bin"):$(PATH)
 PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../IDE")
@@ -531,15 +491,12 @@ export LIB := $(LIB);$(WindowsSdkDir);$(INETSDK)/Lib
 TARGET := $(TARGET_NAME)_libretro.dll
 PSS_STYLE :=2
 LDFLAGS += -DLL
-CFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 CXXFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 # Windows
 else
-   CFLAGS += $(LTO)
    CXXFLAGS += $(LTO)
    LDFLAGS += $(LTO)
    TARGET := $(TARGET_NAME)_libretro.dll
-   CC = gcc
    CXX = g++
    SHARED := -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T
    CXXFLAGS += -D__WIN32__
@@ -549,35 +506,27 @@ CORE_DIR := ..
 
 ifeq ($(DEBUG), 1)
    ifneq (,$(findstring msvc,$(platform)))
-      CFLAGS += -Od -Zi -DDEBUG -D_DEBUG
       CXXFLAGS += -Od -Zi -DDEBUG -D_DEBUG
 
       ifeq ($(STATIC_LINKING),1)
-         CFLAGS += -MTd
          CXXFLAGS += -MTd
       else
-         CFLAGS += -MDd
          CXXFLAGS += -MDd
       endif
    else
-      CFLAGS += -O0 -g -DDEBUG
       CXXFLAGS += -O0 -g -DDEBUG
    endif
 else
 ifneq (,$(findstring msvc,$(platform)))
-   CFLAGS += -O2 -DNDEBUG
    CXXFLAGS += -O2 -DNDEBUG
 else
-   CFLAGS += -O3 -DNDEBUG
    CXXFLAGS += -O3 -DNDEBUG
 endif
 
    ifneq (,$(findstring msvc,$(platform)))
       ifeq ($(STATIC_LINKING),1)
-         CFLAGS += -MT
          CXXFLAGS += -MT
       else
-         CFLAGS += -MD
          CXXFLAGS += -MD
       endif
    endif
@@ -598,15 +547,9 @@ else
    CODE_DEFINES = -fomit-frame-pointer
 endif
 
-CXXFLAGS	+= $(CODE_DEFINES) $(WARNINGS_DEFINES) $(fpic)
-CXXFLAGS	+= -D__LIB_RETRO__ -DSOUND_SUPPORT
-CFLAGS		= $(CXXFLAGS)
-CFLAGS      += -DHAVE_STDINT_H
-CXXFLAGS    += -DHAVE_STDINT_H
-
-ifeq ($(platform), emscripten)
-    CFLAGS := $(filter-out -std=c++14,$(CFLAGS))
-endif
+CXXFLAGS += $(CODE_DEFINES) $(WARNINGS_DEFINES) $(fpic)
+CXXFLAGS += -D__LIB_RETRO__ -DSOUND_SUPPORT
+CXXFLAGS += -DHAVE_STDINT_H
 
 ifeq (,$(findstring msvc,$(platform)))
    ifeq ($(HAVE_STRINGS_H), 1)
@@ -638,7 +581,6 @@ INCFLAGS += $(INCFLAGS_PLATFORM)
 
 ifeq ($(platform), theos_ios)
 COMMON_FLAGS := -DIOS -DARM $(COMMON_DEFINES) $(INCFLAGS) -I$(THEOS_INCLUDE_PATH) -Wno-error
-$(LIBRARY_NAME)_CFLAGS += $(CFLAGS) $(COMMON_FLAGS)
 $(LIBRARY_NAME)_CXXFLAGS += $(CXXFLAGS) $(COMMON_FLAGS)
 ${LIBRARY_NAME}_FILES = $(SOURCES_CXX) $(SOURCES_C)
 include $(THEOS_MAKE_PATH)/library.mk
@@ -654,9 +596,6 @@ endif
 
 %.o: %.cxx
 	$(CXX) $(INCFLAGS) $(CPPFLAGS) $(CXXFLAGS) -c $(OBJOUT)$@ $<
-
-%.o: %.c
-	$(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 clean:
 	rm -f $(OBJECTS) $(TARGET)

--- a/src/libretro/Makefile.common
+++ b/src/libretro/Makefile.common
@@ -128,5 +128,3 @@ SOURCES_CXX := \
 	$(CORE_DIR)/emucore/Switches.cxx \
 	$(CORE_DIR)/emucore/System.cxx \
 	$(CORE_DIR)/emucore/Thumbulator.cxx
-
-SOURCES_C :=


### PR DESCRIPTION
The libretro Makefile is honestly a mess right now and I'd like to spend some time cleaning it up so lets start with removing some unusued stuff.

Note my assumption is that stella is a c++ program and any c code would be external dependencies which the libretro core does not depend on anymore.