### PR TITLE
libretro: Add -stdlib=libc++ to the LDFLAGS for osx too.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -87,7 +87,7 @@ ifneq (,$(findstring unix,$(platform)))
 # OS X
 else ifeq ($(platform), osx)
    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
-   LDFLAGS += $(LTO) $(PTHREAD_FLAGS)
+   LDFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC
    SHARED := -dynamiclib


### PR DESCRIPTION
The last two PRs (https://github.com/stella-emu/stella/pull/449 and https://github.com/stella-emu/stella/pull/450) made progress, now osx is failing on linking with many undefined c++ references. I am thinking it probably needs `-stdlib=libc++` in the `LDFLAGS` too?

For reference see this log.

[stella-osx-x64-generic.log](https://github.com/stella-emu/stella/files/3142107/stella-osx-x64-generic.log)