### PR TITLE
libretro: Fix identing in the Makefile.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -47,12 +47,13 @@ ifneq ($(platform), osx)
    endif
 endif
 
-TARGET_NAME	= stella
+TARGET_NAME = stella
 
-LIBS     =
 
 ifeq (,$(findstring msvc,$(platform)))
-LIBS		+= -lm
+   LIBS := -lm
+else
+   LIBS :=
 endif
 
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
@@ -71,9 +72,6 @@ ifneq (,$(findstring unix,$(platform)))
       SHARED := -shared -z defs
    else
       SHARED := -shared -Wl,--version-script=link.T -Wl,-z,defs
-   endif
-   ifneq ($(findstring Haiku,$(shell uname -a)),)
-      LIBS :=
    endif
 
    # ARM
@@ -121,31 +119,30 @@ else ifeq ($(platform), libnx)
 # (armv7 a7, hard point, neon based) ###
 # NESC, SNESC, C64 mini
 else ifeq ($(platform), classic_armv7_a7)
-	TARGET := $(TARGET_NAME)_libretro.so
-	fpic := -fPIC
-	SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
-	CXXFLAGS += -Ofast \
-	-flto=4 -fwhole-program -fuse-linker-plugin \
-	-fdata-sections -ffunction-sections -Wl,--gc-sections \
-	-fno-stack-protector -fno-ident -fomit-frame-pointer \
-	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
-	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
-	-fmerge-all-constants -fno-math-errno \
-	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-	HAVE_NEON = 1
-	ARCH = arm
-	BUILTIN_GPU = neon
-	USE_DYNAREC = 1
-	ifeq ($(shell echo `$(CXX) -dumpversion` "< 4.9" | bc -l), 1)
-	  CXXFLAGS += -march=armv7-a
-	else
-	  CXXFLAGS += -march=armv7ve
-	  # If gcc is 5.0 or later
-	  ifeq ($(shell echo `$(CXX) -dumpversion` ">= 5" | bc -l), 1)
-	    LDFLAGS += -static-libgcc -static-libstdc++
-	  endif
-	endif
-#######################################
+   TARGET := $(TARGET_NAME)_libretro.so
+   fpic := -fPIC
+   SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
+   CXXFLAGS += -Ofast \
+               -flto=4 -fwhole-program -fuse-linker-plugin \
+               -fdata-sections -ffunction-sections -Wl,--gc-sections \
+               -fno-stack-protector -fno-ident -fomit-frame-pointer \
+               -falign-functions=1 -falign-jumps=1 -falign-loops=1 \
+               -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
+               -fmerge-all-constants -fno-math-errno \
+              -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+   HAVE_NEON = 1
+   ARCH = arm
+   BUILTIN_GPU = neon
+   USE_DYNAREC = 1
+   ifeq ($(shell echo `$(CXX) -dumpversion` "< 4.9" | bc -l), 1)
+      CXXFLAGS += -march=armv7-a
+   else
+      CXXFLAGS += -march=armv7ve
+      # If gcc is 5.0 or later
+      ifeq ($(shell echo `$(CXX) -dumpversion` ">= 5" | bc -l), 1)
+         LDFLAGS += -static-libgcc -static-libstdc++
+      endif
+   endif
 
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
@@ -158,9 +155,9 @@ else ifneq (,$(findstring ios,$(platform)))
       IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
    endif
    ifeq ($(platform),ios-arm64)
-		CXX = clang++ -arch arm64 -isysroot $(IOSSDK)
+      CXX = clang++ -arch arm64 -isysroot $(IOSSDK)
    else
-		CXX = clang++ -arch armv7 -isysroot $(IOSSDK)
+      CXX = clang++ -arch armv7 -isysroot $(IOSSDK)
    endif
    CXXFLAGS += -DIOS
    CXXFLAGS += -DARM
@@ -218,12 +215,10 @@ else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
       TARGET := $(TARGET_NAME)_libretro_ps3.a
       CXX = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
       AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
-
    # PS3
    else ifneq (,$(findstring ps3,$(platform)))
       CXX = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-g++.exe
       AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-
    # Lightweight PS3 Homebrew SDK
    else ifneq (,$(findstring psl1ght,$(platform)))
       CXX = $(PS3DEV)/ppu/bin/ppu-g++$(EXE_EXT)
@@ -253,11 +248,9 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    # Nintendo WiiU
    ifneq (,$(findstring wiiu,$(platform)))
       CXXFLAGS += -mwup
-
    # Nintendo Wii
    else ifneq (,$(findstring wii,$(platform)))
       CXXFLAGS += -DGEKKO -mrvl
-
    # Nintendo Game Cube
    else ifneq (,$(findstring ngc,$(platform)))
       CXXFLAGS += -DGEKKO -mrvl
@@ -283,216 +276,216 @@ else ifeq ($(platform), genode)
    CXX = $(shell pkg-config genode-base --variable=cxx)
    LD  = $(shell pkg-config genode-base --variable=ld)
    AR  = $(shell pkg-config genode-base --variable=ar) -rcs
-   LIBS =
 
 # Windows MSVC 2003 Xbox 1
 else ifeq ($(platform), xbox1_msvc2003)
-CXXFLAGS += -D__WIN32__
-TARGET := $(TARGET_NAME)_libretro_xdk1.lib
-MSVCBINDIRPREFIX = $(XDK)/xbox/bin/vc71
-CXX  = "$(MSVCBINDIRPREFIX)/CL.exe"
-LD   = "$(MSVCBINDIRPREFIX)/lib.exe"
+   CXXFLAGS += -D__WIN32__
+   TARGET := $(TARGET_NAME)_libretro_xdk1.lib
+   MSVCBINDIRPREFIX = $(XDK)/xbox/bin/vc71
+   CXX  = "$(MSVCBINDIRPREFIX)/CL.exe"
+   LD   = "$(MSVCBINDIRPREFIX)/lib.exe"
 
-export INCLUDE := $(XDK)/xbox/include
-export LIB := $(XDK)/xbox/lib
-PSS_STYLE :=2
-CXXFLAGS += -D_XBOX -D_XBOX1
-STATIC_LINKING=1
-HAS_GCC := 0
+   export INCLUDE := $(XDK)/xbox/include
+   export LIB := $(XDK)/xbox/lib
+   PSS_STYLE :=2
+   CXXFLAGS += -D_XBOX -D_XBOX1
+   STATIC_LINKING=1
+   HAS_GCC := 0
+
 # Windows MSVC 2010 Xbox 360
 else ifeq ($(platform), xbox360_msvc2010)
-CXXFLAGS += -D__WIN32__
-TARGET := $(TARGET_NAME)_libretro_xdk360.lib
-MSVCBINDIRPREFIX = $(XEDK)/bin/win32
-CXX  = "$(MSVCBINDIRPREFIX)/cl.exe"
-LD   = "$(MSVCBINDIRPREFIX)/lib.exe"
+   CXXFLAGS += -D__WIN32__
+   TARGET := $(TARGET_NAME)_libretro_xdk360.lib
+   MSVCBINDIRPREFIX = $(XEDK)/bin/win32
+   CXX  = "$(MSVCBINDIRPREFIX)/cl.exe"
+   LD   = "$(MSVCBINDIRPREFIX)/lib.exe"
 
-export INCLUDE := $(XEDK)/include/xbox
-export LIB := $(XEDK)/lib/xbox
-PSS_STYLE :=2
-CXXFLAGS += -D_XBOX -D_XBOX360
-STATIC_LINKING=1
-HAS_GCC := 0
+   export INCLUDE := $(XEDK)/include/xbox
+   export LIB := $(XEDK)/lib/xbox
+   PSS_STYLE :=2
+   CXXFLAGS += -D_XBOX -D_XBOX360
+   STATIC_LINKING=1
+   HAS_GCC := 0
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))
-    CXXFLAGS += -D__WIN32__
+   CXXFLAGS += -D__WIN32__
 
-	PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
-	ifneq (,$(findstring desktop,$(PlatformSuffix)))
-		WinPartition = desktop
-        MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP
-		LDFLAGS += -MANIFEST -LTCG:incremental -NXCOMPAT -DYNAMICBASE -DEBUG -OPT:REF -INCREMENTAL:NO -SUBSYSTEM:WINDOWS -MANIFESTUAC:"level='asInvoker' uiAccess='false'" -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1
-		LIBS += kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib
-	else ifneq (,$(findstring uwp,$(PlatformSuffix)))
-		WinPartition = uwp
-		MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WINDLL -D_UNICODE -DUNICODE -D__WRL_NO_DEFAULT_LIB__ -ZW:nostdlib -EHsc
-		LDFLAGS += -APPCONTAINER -NXCOMPAT -DYNAMICBASE -MANIFEST:NO -LTCG -OPT:REF -SUBSYSTEM:CONSOLE -MANIFESTUAC:NO -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1 -DEBUG:FULL -WINMD:NO
-		LIBS += WindowsApp.lib
-	endif
+   PlatformSuffix = $(subst windows_msvc2017_,,$(platform))
+   ifneq (,$(findstring desktop,$(PlatformSuffix)))
+      WinPartition = desktop
+      MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP
+      LDFLAGS += -MANIFEST -LTCG:incremental -NXCOMPAT -DYNAMICBASE -DEBUG -OPT:REF -INCREMENTAL:NO -SUBSYSTEM:WINDOWS -MANIFESTUAC:"level='asInvoker' uiAccess='false'" -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1
+      LIBS += kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib
+   else ifneq (,$(findstring uwp,$(PlatformSuffix)))
+      WinPartition = uwp
+      MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WINDLL -D_UNICODE -DUNICODE -D__WRL_NO_DEFAULT_LIB__ -ZW:nostdlib -EHsc
+      LDFLAGS += -APPCONTAINER -NXCOMPAT -DYNAMICBASE -MANIFEST:NO -LTCG -OPT:REF -SUBSYSTEM:CONSOLE -MANIFESTUAC:NO -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1 -DEBUG:FULL -WINMD:NO
+      LIBS += WindowsApp.lib
+   endif
 
-	# Specific to this core
-	MSVC2017CompileFlags += -D__WIN32__ /std:c++17
+   # Specific to this core
+   MSVC2017CompileFlags += -D__WIN32__ /std:c++17
 
-	CXXFLAGS += $(MSVC2017CompileFlags)
+   CXX = cl.exe
+   CXXFLAGS += $(MSVC2017CompileFlags)
 
-	TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
+   TargetArchMoniker = $(subst $(WinPartition)_,,$(PlatformSuffix))
 
-	CXX = cl.exe
+   reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
+   fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
-	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
-	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
+   ProgramFiles86w := $(shell cmd /c "echo %PROGRAMFILES(x86)%")
+   ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
 
-	ProgramFiles86w := $(shell cmd /c "echo %PROGRAMFILES(x86)%")
-	ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
+   WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+   WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
+   WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+   WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
+   WindowsSdkDir := $(WindowsSdkDir)
 
-	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
-	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)
-	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
-	WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_CURRENT_USER\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0)
-	WindowsSdkDir := $(WindowsSdkDir)
+   WindowsSDKVersion ?= $(firstword $(foreach folder,$(subst $(subst \,/,$(WindowsSdkDir)Include/),,$(wildcard $(call fix_path,$(WindowsSdkDir)Include\*))),$(if $(wildcard $(call fix_path,$(WindowsSdkDir)Include/$(folder)/um/Windows.h)),$(folder),)))$(BACKSLASH)
+   WindowsSDKVersion := $(WindowsSDKVersion)
 
-	WindowsSDKVersion ?= $(firstword $(foreach folder,$(subst $(subst \,/,$(WindowsSdkDir)Include/),,$(wildcard $(call fix_path,$(WindowsSdkDir)Include\*))),$(if $(wildcard $(call fix_path,$(WindowsSdkDir)Include/$(folder)/um/Windows.h)),$(folder),)))$(BACKSLASH)
-	WindowsSDKVersion := $(WindowsSDKVersion)
+   VsInstallBuildTools = $(ProgramFiles86)/Microsoft Visual Studio/2017/BuildTools
+   VsInstallEnterprise = $(ProgramFiles86)/Microsoft Visual Studio/2017/Enterprise
+   VsInstallProfessional = $(ProgramFiles86)/Microsoft Visual Studio/2017/Professional
+   VsInstallCommunity = $(ProgramFiles86)/Microsoft Visual Studio/2017/Community
+   VsInstallRoot ?= $(shell if [ -d "$(VsInstallBuildTools)" ]; then echo "$(VsInstallBuildTools)"; fi)
 
-	VsInstallBuildTools = $(ProgramFiles86)/Microsoft Visual Studio/2017/BuildTools
-	VsInstallEnterprise = $(ProgramFiles86)/Microsoft Visual Studio/2017/Enterprise
-	VsInstallProfessional = $(ProgramFiles86)/Microsoft Visual Studio/2017/Professional
-	VsInstallCommunity = $(ProgramFiles86)/Microsoft Visual Studio/2017/Community
+   ifeq ($(VsInstallRoot), )
+      VsInstallRoot = $(shell if [ -d "$(VsInstallEnterprise)" ]; then echo "$(VsInstallEnterprise)"; fi)
+   endif
+   ifeq ($(VsInstallRoot), )
+      VsInstallRoot = $(shell if [ -d "$(VsInstallProfessional)" ]; then echo "$(VsInstallProfessional)"; fi)
+   endif
+   ifeq ($(VsInstallRoot), )
+      VsInstallRoot = $(shell if [ -d "$(VsInstallCommunity)" ]; then echo "$(VsInstallCommunity)"; fi)
+   endif
 
-	VsInstallRoot ?= $(shell if [ -d "$(VsInstallBuildTools)" ]; then echo "$(VsInstallBuildTools)"; fi)
-	ifeq ($(VsInstallRoot), )
-		VsInstallRoot = $(shell if [ -d "$(VsInstallEnterprise)" ]; then echo "$(VsInstallEnterprise)"; fi)
-	endif
-	ifeq ($(VsInstallRoot), )
-		VsInstallRoot = $(shell if [ -d "$(VsInstallProfessional)" ]; then echo "$(VsInstallProfessional)"; fi)
-	endif
-	ifeq ($(VsInstallRoot), )
-		VsInstallRoot = $(shell if [ -d "$(VsInstallCommunity)" ]; then echo "$(VsInstallCommunity)"; fi)
-	endif
-	VsInstallRoot := $(VsInstallRoot)
+   VsInstallRoot := $(VsInstallRoot)
+   VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
+   VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
 
-	VcCompilerToolsVer := $(shell cat "$(VsInstallRoot)/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt" | grep -o '[0-9\.]*')
-	VcCompilerToolsDir := $(VsInstallRoot)/VC/Tools/MSVC/$(VcCompilerToolsVer)
+   WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
+   WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
+   WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
+   WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
+   WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
 
-	WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
-	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
-	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
-	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
-	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
+   # For some reason the HostX86 compiler doesn't like compiling for x64
+   # ("no such file" opening a shared library), and vice-versa.
+   # Work around it for now by using the strictly x86 compiler for x86, and x64 for x64.
+   # NOTE: What about ARM?
+   ifneq (,$(findstring x64,$(TargetArchMoniker)))
+      VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX64
+   else
+      VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX86
+   endif
 
-	# For some reason the HostX86 compiler doesn't like compiling for x64
-	# ("no such file" opening a shared library), and vice-versa.
-	# Work around it for now by using the strictly x86 compiler for x86, and x64 for x64.
-	# NOTE: What about ARM?
-	ifneq (,$(findstring x64,$(TargetArchMoniker)))
-		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX64
-	else
-		VCCompilerToolsBinDir := $(VcCompilerToolsDir)\bin\HostX86
-	endif
+   PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
+   PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
+   INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
+   ifneq (,$(findstring uwp,$(PlatformSuffix)))
+      LIB := $(shell IFS=$$'\n'; cygpath -w "$(LIB)/store")
+   else
+      LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
+   endif
 
-	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)/$(TargetArchMoniker)"):$(PATH)
-	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
-	INCLUDE := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/include")
-	LIB := $(shell IFS=$$'\n'; cygpath -w "$(VcCompilerToolsDir)/lib/$(TargetArchMoniker)")
-	ifneq (,$(findstring uwp,$(PlatformSuffix)))
-		LIB := $(shell IFS=$$'\n'; cygpath -w "$(LIB)/store")
-	endif
-
-	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
-	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)
-	TARGET := $(TARGET_NAME)_libretro.dll
-	PSS_STYLE :=2
-	LDFLAGS += -DLL
+   export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
+   export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir)
+   TARGET := $(TARGET_NAME)_libretro.dll
+   PSS_STYLE :=2
+   LDFLAGS += -DLL
 
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)
    CXXFLAGS += -D__WIN32__
    CXX = cl.exe
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin/amd64"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
-LIB := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/lib/amd64")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
+   PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin/amd64"):$(PATH)
+   PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
+   LIB := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/lib/amd64")
+   INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
 
-WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
-WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+   WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
+   WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib/x64
 
-WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
-WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+   WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+   WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
 
+   INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
+   export INCLUDE := $(INCLUDE)
+   export LIB := $(LIB);$(WindowsSdkDir)
+   TARGET := $(TARGET_NAME)_libretro.dll
+   PSS_STYLE :=2
+   LDFLAGS += -DLL
+   LIBS :=
 
-INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
-export INCLUDE := $(INCLUDE)
-export LIB := $(LIB);$(WindowsSdkDir)
-TARGET := $(TARGET_NAME)_libretro.dll
-PSS_STYLE :=2
-LDFLAGS += -DLL
-LIBS :=
 # Windows MSVC 2010 x86
 else ifeq ($(platform), windows_msvc2010_x86)
    CXXFLAGS += -D__WIN32__
    CXX = cl.exe
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
-LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS100COMNTOOLS)../../VC/lib")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
+   PATH := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/bin"):$(PATH)
+   PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../IDE")
+   LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS100COMNTOOLS)../../VC/lib")
+   INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS100COMNTOOLS)../../VC/include")
 
-WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
-WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
+   WindowsSdkDir := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
+   WindowsSdkDir ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')lib
 
-WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
-WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+   WindowsSdkDirInc := $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
+   WindowsSdkDirInc ?= $(shell reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A" -v "InstallationFolder" | grep -o '[A-Z]:\\.*')Include
 
-
-INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
-export INCLUDE := $(INCLUDE)
-export LIB := $(LIB);$(WindowsSdkDir)
-TARGET := $(TARGET_NAME)_libretro.dll
-PSS_STYLE :=2
-LDFLAGS += -DLL
-LIBS :=
+   INCFLAGS_PLATFORM = -I"$(WindowsSdkDirInc)"
+   export INCLUDE := $(INCLUDE)
+   export LIB := $(LIB);$(WindowsSdkDir)
+   TARGET := $(TARGET_NAME)_libretro.dll
+   PSS_STYLE :=2
+   LDFLAGS += -DLL
+   LIBS :=
 
 # Windows MSVC 2003 x86
 else ifeq ($(platform), windows_msvc2003_x86)
    CXXFLAGS += -D__WIN32__
    CXX = cl.exe
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../../Vc7/bin"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../IDE")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../../Vc7/include")
-LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS71COMNTOOLS)../../Vc7/lib")
-BIN := $(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../../Vc7/bin")
+   PATH := $(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../../Vc7/bin"):$(PATH)
+   PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../IDE")
+   INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../../Vc7/include")
+   LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS71COMNTOOLS)../../Vc7/lib")
+   BIN := $(shell IFS=$$'\n'; cygpath "$(VS71COMNTOOLS)../../Vc7/bin")
 
-WindowsSdkDir := $(INETSDK)
+   WindowsSdkDir := $(INETSDK)
 
-export INCLUDE := $(INCLUDE);$(INETSDK)/Include;src/drivers/libretro/msvc/msvc-2005
-export LIB := $(LIB);$(WindowsSdkDir);$(INETSDK)/Lib
-TARGET := $(TARGET_NAME)_libretro.dll
-PSS_STYLE :=2
-LDFLAGS += -DLL
-CXXFLAGS += -D_CRT_SECURE_NO_DEPRECATE
+   export INCLUDE := $(INCLUDE);$(INETSDK)/Include;src/drivers/libretro/msvc/msvc-2005
+   export LIB := $(LIB);$(WindowsSdkDir);$(INETSDK)/Lib
+   TARGET := $(TARGET_NAME)_libretro.dll
+   PSS_STYLE :=2
+   LDFLAGS += -DLL
+   CXXFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 
 # Windows MSVC 2005 x86
 else ifeq ($(platform), windows_msvc2005_x86)
    CXXFLAGS += -D__WIN32__
    CXX = cl.exe
 
-PATH := $(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../../VC/bin"):$(PATH)
-PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../IDE")
-INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../../VC/include")
-LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS80COMNTOOLS)../../VC/lib")
-BIN := $(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../../VC/bin")
+   PATH := $(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../../VC/bin"):$(PATH)
+   PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../IDE")
+   INCLUDE := $(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../../VC/include")
+   LIB := $(shell IFS=$$'\n'; cygpath -w "$(VS80COMNTOOLS)../../VC/lib")
+   BIN := $(shell IFS=$$'\n'; cygpath "$(VS80COMNTOOLS)../../VC/bin")
 
-WindowsSdkDir := $(INETSDK)
+   WindowsSdkDir := $(INETSDK)
 
-export INCLUDE := $(INCLUDE);$(INETSDK)/Include;libretro-common/include/compat/msvc
-export LIB := $(LIB);$(WindowsSdkDir);$(INETSDK)/Lib
-TARGET := $(TARGET_NAME)_libretro.dll
-PSS_STYLE :=2
-LDFLAGS += -DLL
-CXXFLAGS += -D_CRT_SECURE_NO_DEPRECATE
+   export INCLUDE := $(INCLUDE);$(INETSDK)/Include;libretro-common/include/compat/msvc
+   export LIB := $(LIB);$(WindowsSdkDir);$(INETSDK)/Lib
+   TARGET := $(TARGET_NAME)_libretro.dll
+   PSS_STYLE :=2
+   LDFLAGS += -DLL
+   CXXFLAGS += -D_CRT_SECURE_NO_DEPRECATE
+
 # Windows
 else
    CXXFLAGS += $(LTO)
@@ -518,11 +511,11 @@ ifeq ($(DEBUG), 1)
       CXXFLAGS += -O0 -g -DDEBUG
    endif
 else
-ifneq (,$(findstring msvc,$(platform)))
-   CXXFLAGS += -O2 -DNDEBUG
-else
-   CXXFLAGS += -O3 -DNDEBUG
-endif
+   ifneq (,$(findstring msvc,$(platform)))
+      CXXFLAGS += -O2 -DNDEBUG
+   else
+      CXXFLAGS += -O3 -DNDEBUG
+   endif
 
    ifneq (,$(findstring msvc,$(platform)))
       ifeq ($(STATIC_LINKING),1)
@@ -562,29 +555,29 @@ ifeq (,$(findstring msvc,$(platform)))
    endif
 endif
 
-OBJOUT   = -o
-LINKOUT  = -o
+OBJOUT  = -o
+LINKOUT = -o
 
 ifneq (,$(findstring msvc,$(platform)))
-	OBJOUT = -Fo
-	LINKOUT = -out:
-ifeq ($(STATIC_LINKING),1)
-	LD ?= lib.exe
-	STATIC_LINKING=0
-else
-	LD = link.exe
-endif
+   OBJOUT = -Fo
+   LINKOUT = -out:
+   ifeq ($(STATIC_LINKING),1)
+      LD ?= lib.exe
+      STATIC_LINKING=0
+   else
+      LD = link.exe
+   endif
 else ifneq ($(platform),genode)
-	LD = $(CXX)
+   LD = $(CXX)
 endif
 
 INCFLAGS += $(INCFLAGS_PLATFORM)
 
 ifeq ($(platform), theos_ios)
-COMMON_FLAGS := -DIOS -DARM $(COMMON_DEFINES) $(INCFLAGS) -I$(THEOS_INCLUDE_PATH) -Wno-error
-$(LIBRARY_NAME)_CXXFLAGS += $(CXXFLAGS) $(COMMON_FLAGS)
-${LIBRARY_NAME}_FILES = $(SOURCES_CXX) $(SOURCES_C)
-include $(THEOS_MAKE_PATH)/library.mk
+   COMMON_FLAGS := -DIOS -DARM $(COMMON_DEFINES) $(INCFLAGS) -I$(THEOS_INCLUDE_PATH) -Wno-error
+   $(LIBRARY_NAME)_CXXFLAGS += $(CXXFLAGS) $(COMMON_FLAGS)
+   ${LIBRARY_NAME}_FILES = $(SOURCES_CXX) $(SOURCES_C)
+   include $(THEOS_MAKE_PATH)/library.mk
 else
 all: $(TARGET)
 


### PR DESCRIPTION
This should have no changes in behavior and I did two things.

1. The Makefile is full of both tabs and inconsistent spacing, this make it much harder to read and I changed everything that I could to use three spaces as is standard in libretro projects. If other styles are preferred I can do that.
2. I removed a few redundant variables I noticed while doing the former, for example `LIB` was set to the same value in some places.