### PR TITLE
libretro: Hide compiler options from msvc.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -10,11 +10,11 @@ BACKSLASH := \$(BACKSLASH)
 filter_out1 = $(filter-out $(firstword $1),$1)
 filter_out2 = $(call filter_out1,$(call filter_out1,$1))
 
-CXXFLAGS += -Wall -Wunused -fno-rtti -Woverloaded-virtual
-CXXFLAGS += -Wnon-virtual-dtor -std=c++14
+CXXFLAGS += -std=c++14 -Wall
 
 ifeq (,$(findstring msvc,$(platform)))
-   CXXFLAGS += -Wextra -Wno-unused-parameter -Wno-multichar
+   CXXFLAGS += -Wextra -Wno-unused-parameter -Wno-multichar -Wunused -fno-rtti \
+               -Woverloaded-virtual -Wnon-virtual-dtor
 endif
 
 ifeq ($(platform),)


### PR DESCRIPTION
Instead of disabling them one by one I found some documentation.

Reference: https://docs.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=vs-2019

Not surprisingly the only ones listed in this list are `-Wall` and `-std`...

For reference here is the current error.
```
cl : Command line error D8021 : invalid numeric argument '/Wunused'
make: *** [Makefile:591: ../libretro/libretro.o] Error 2
make: *** Waiting for unfinished jobs....
make: *** [Makefile:591: ../libretro/EventHandlerLIBRETRO.o] Error 2
```