### PR TITLE
libretro: Fix build.

### DIFF
--- a/src/emucore/Paddles.cxx
+++ b/src/emucore/Paddles.cxx
@@ -15,6 +15,8 @@
 // this file, and for a DISCLAIMER OF ALL WARRANTIES.
 //============================================================================
 
+#include <cmath>
+
 #include "Event.hxx"
 #include "Paddles.hxx"
 


### PR DESCRIPTION
Fixes the libretro build which is broken again on at least linux, mingw and osx.
```
../emucore/Paddles.cxx: In member function ‘virtual void Paddles::update()’:
../emucore/Paddles.cxx:269:27: error: ‘pow’ is not a member of ‘std’
  269 |     double dFactor = std::pow(factor1, 1 / (abs(sa_xaxis - myLastAxisX) * factor2));
      |                           ^~~
../emucore/Paddles.cxx:278:27: error: ‘pow’ is not a member of ‘std’
  278 |     double dFactor = std::pow(factor1, 1 / (abs(sa_yaxis - myLastAxisY) * factor2));
      |                           ^~~
make: *** [Makefile:591: ../emucore/Paddles.o] Error 1
```