### PR TITLE
libretro: Silence clang warnings for unix.

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -62,7 +62,7 @@ endif
 
 # Unix
 ifneq (,$(findstring unix,$(platform)))
-   CXXFLAGS += $(LTO) $(PTHREAD_FLAGS)
+   CXXFLAGS += $(LTO)
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC


### PR DESCRIPTION
With `clang-8.0.0` on linux the libretro compile will warn many times.
```
clang-8: warning: -lpthread: 'linker' input unused [-Wunused-command-line-argument]
```
I think `-lpthread` is just for linking and not useful for compiling so I updated the libretro makefile accordingly.

Reference: https://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling

I did this only for unix which I can test.
