### PR TITLE
(Libretro/MSVC 2017) Buildfix

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -357,7 +357,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
    reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
    fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
-   ProgramFiles86w := $(shell cmd /c "echo %PROGRAMFILES(x86)%")
+   ProgramFiles86w := $(shell cmd //c "echo %PROGRAMFILES(x86)%")
    ProgramFiles86 := $(shell cygpath "$(ProgramFiles86w)")
 
    WindowsSdkDir ?= $(call reg_query,InstallationFolder,HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0)


### PR DESCRIPTION
Hi there,

with this buildfix, the MSVC 2017 libretro targets should compile again. This can help us out immensely on the buildbot.