### PR TITLE
Remove extra quote for audio presets

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2155,7 +2155,7 @@
   <tr>
     <td><pre>-audio.preset &lt;1 - 5&gt;</pre></td>
     <td>Set an audio preset. Numbers in sequence represent presets for
-    'custom', 'low quality, 'medium lag', 'high quality, medium lag',
+    'custom', 'low quality, medium lag', 'high quality, medium lag',
     'high quality, low lag' and 'ultra quality, minimal lag'.</td>
   </tr>
 


### PR DESCRIPTION
The list of presets includes an extra quote in "low quality, medium
lag"; this patch removes it.

Signed-off-by: Stephen Kitt <steve@sk2.org>