### PR TITLE
Attempt to fix libretro armv7-neon build

### DIFF
--- a/src/common/tv_filters/AtariNTSC.hxx
+++ b/src/common/tv_filters/AtariNTSC.hxx
@@ -169,15 +169,15 @@ class AtariNTSC
 
     struct init_t
     {
-      std::array<float, burst_count * 6> to_rgb{0.F};
+      std::array<float, burst_count * 6> to_rgb{{0.F}};
     #ifdef BLARGG_PALETTE
-      std::array<float, gamma_size> to_float{0.F};
+      std::array<float, gamma_size> to_float{{0.F}};
       float contrast{0.F};
       float brightness{0.F};
     #endif
       float artifacts{0.F};
       float fringing{0.F};
-      std::array<float, rescale_out * kernel_size * 2> kernel{0.F};
+      std::array<float, rescale_out * kernel_size * 2> kernel{{0.F}};
 
       init_t() {
         to_rgb.fill(0.0);
@@ -193,7 +193,7 @@ class AtariNTSC
     {
       int offset{0};
       float negate{0.F};
-      std::array<float, 4> kernel{0.F};
+      std::array<float, 4> kernel{{0.F}};
     };
     static const std::array<pixel_info_t, alignment_count> atari_ntsc_pixels;
 

--- a/src/emucore/Control.hxx
+++ b/src/emucore/Control.hxx
@@ -381,10 +381,10 @@ class Controller : public Serializable
 
   private:
     /// The boolean value on each digital pin
-    std::array<bool, 5> myDigitalPinState{true, true, true, true, true};
+    std::array<bool, 5> myDigitalPinState{{true, true, true, true, true}};
 
     /// The analog value on each analog pin
-    std::array<Int32, 2> myAnalogPinValue{MAX_RESISTANCE, MAX_RESISTANCE};
+    std::array<Int32, 2> myAnalogPinValue{{MAX_RESISTANCE, MAX_RESISTANCE}};
 
   private:
     // Following constructors and assignment operators not supported

--- a/src/emucore/M6532.hxx
+++ b/src/emucore/M6532.hxx
@@ -225,7 +225,7 @@ class M6532 : public Device
     bool myEdgeDetectPositive{false};
 
     // Last value written to the timer registers
-    std::array<uInt8, 4> myOutTimer{0};
+    std::array<uInt8, 4> myOutTimer{{0}};
 
     // Accessible bits in the interrupt flag register
     // All other bits are always zeroed

--- a/src/emucore/Paddles.hxx
+++ b/src/emucore/Paddles.hxx
@@ -178,7 +178,7 @@ class Paddles : public Controller
 
     bool myKeyRepeat0{false}, myKeyRepeat1{false};
     int myPaddleRepeat0{0}, myPaddleRepeat1{0};
-    std::array<int, 2> myCharge{TRIGRANGE/2, TRIGRANGE/2}, myLastCharge{0};
+    std::array<int, 2> myCharge{{TRIGRANGE/2, TRIGRANGE/2}}, myLastCharge{{0}};
     int myLastAxisX{0}, myLastAxisY{0};
     int myAxisDigitalZero{0}, myAxisDigitalOne{0};
 


### PR DESCRIPTION
Error log: http://paste.libretro.com/202635

This PR takes care of errors like `error: array must be initialized with a brace-enclosed initializer`

But there are also other errors like `error: enclosing class of constexpr non-static member function 'uInt32 StellaLIBRETRO::getROMMax() const' is not a literal type` that are no fixed here.

Why these errors happen on our arm build bot only is still a mystery to me.