### PR TITLE
Create .gitlab-ci.yml - for new Libretro build infrastructure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,68 @@
+.core-defs:
+  variables:
+    JNI_PATH: src/libretro
+    CORENAME: stella
+
+include:
+  - template: Jobs/Code-Quality.gitlab-ci.yml
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/libnx-static.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-x64.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-mingw.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-jni.yml'
+
+stages:
+  - build-prepare
+  - build-shared
+  - build-static
+  - test
+
+#Desktop
+libretro-build-linux-x64:
+  extends:
+    - .core-defs
+    - .libretro-linux-x64-make-default
+  variables:
+    MAKEFILE_PATH: src/libretro
+    MAKEFILE: Makefile
+
+libretro-build-windows-x64:
+  extends:
+    - .core-defs
+    - .libretro-windows-x64-mingw-make-default
+  variables:
+    MAKEFILE_PATH: src/libretro
+    MAKEFILE: Makefile
+    
+# Android
+android-armeabi-v7a:
+  extends:
+    - .core-defs
+    - .libretro-android-jni-armeabi-v7a
+
+android-arm64-v8a:
+  extends:
+    - .core-defs
+    - .libretro-android-jni-arm64-v8a
+
+android-x86_64:
+  extends:
+    - .core-defs
+    - .libretro-android-jni-x86_64
+    
+android-x86:
+  extends:
+    - .core-defs
+    - .libretro-android-jni-x86
+
+# Static
+libretro-build-libnx-aarch64:
+  extends:
+    - .core-defs
+    - .libretro-libnx-static-retroarch-master
+  variables:
+    MAKEFILE_PATH: src/libretro
+    MAKEFILE: Makefile


### PR DESCRIPTION
Hi there,

we are migrating to a new build server infrastructure. This file will help ensure that each commit triggers a recompile on our buildservers for Libretro. As an additional side bonus, it will help inform if all builds have succeeded per commit for libretro.