### PR TITLE
Implemented input bitmasks

### DIFF
--- a/src/libretro/libretro.h
+++ b/src/libretro/libretro.h
@@ -199,6 +199,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_JOYPAD_R2      13
 #define RETRO_DEVICE_ID_JOYPAD_L3      14
 #define RETRO_DEVICE_ID_JOYPAD_R3      15
+#define RETRO_DEVICE_ID_JOYPAD_MASK   256 
 
 /* Index / Id values for ANALOG device. */
 #define RETRO_DEVICE_INDEX_ANALOG_LEFT       0
@@ -1008,6 +1009,7 @@ enum retro_mod
 											*   never need an accurate audio state in the future.
 											* * State will never be saved when using Hard Disable Audio.
 											*/
+#define RETRO_ENVIRONMENT_GET_INPUT_BITMASKS 51
 
 /* VFS functionality */
 


### PR DESCRIPTION
I've noticed that while input bitmasks have been implemented in libretro's fork of Stella 3.9.3, they're still not implemented in mainline Stella, so here's my attempt.  More information: https://github.com/libretro/RetroArch/issues/11217.