### PR TITLE
(libretro) [unix] Only use static libgcc/libstdc++ if they're present

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -54,10 +54,11 @@ ifneq ($(GIT_VERSION)," unknown")
    CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 
+GET_STATIC_ARG=$(if $(filter $(shell $(CXX) -print-file-name=$1.a),$1.a),,-static-$1)
 # Unix
 ifneq (,$(findstring unix,$(platform)))
    CXXFLAGS += $(LTO)
-   LDFLAGS += $(LTO) $(PTHREAD_FLAGS) -static-libgcc -static-libstdc++
+   LDFLAGS += $(LTO) $(PTHREAD_FLAGS) $(call GET_STATIC_ARG,libgcc) $(call GET_STATIC_ARG,libstdc++)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    ifneq ($(findstring SunOS,$(shell uname -a)),)


### PR DESCRIPTION
Since 6.1.1, compiling the libretro core has required static libgcc and libstdc++, meaning you either have to have them installed or edit the Makefile.  Well, this PR checks whether the static versions are available on the system and only uses them if they are.  I had considered other methods, like a variable, but I like this way because it's automatic.