### PR TITLE
(Libretro/macOS) Add ARM64 rules

### DIFF
--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -102,6 +102,18 @@ else ifeq ($(platform), osx)
    endif
    fpic += $(MINVERSION)
 
+   ifeq ($(CROSS_COMPILE),1)
+		TARGET_RULE   = -target $(LIBRETRO_APPLE_PLATFORM) -isysroot $(LIBRETRO_APPLE_ISYSROOT)
+		CFLAGS   += $(TARGET_RULE)
+		CPPFLAGS += $(TARGET_RULE)
+		CXXFLAGS += $(TARGET_RULE)
+		LDFLAGS  += $(TARGET_RULE)
+   endif
+
+   CFLAGS    += $(ARCHFLAGS)
+   CXXFLAGS  += $(ARCHFLAGS)
+   LDFLAGS   += $(ARCHFLAGS)
+
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
    CXXFLAGS += $(LTO) -stdlib=libc++


### PR DESCRIPTION
Hi there, I'd much appreciate if this could get merged. This should fix the ARM64 libretro core for macOS.