### PR TITLE
joystick: Add menuMode mappings before emulationMode mappings

### DIFF
--- a/src/common/PJoystickHandler.cxx
+++ b/src/common/PJoystickHandler.cxx
@@ -173,8 +173,8 @@ void PhysicalJoystickHandler::addToDatabase(const PhysicalJoystickPtr& stick)
   {
     StickInfo info("", stick);
     myDatabase.emplace(stick->name, info);
-    setStickDefaultMapping(stick->ID, Event::NoType, EventMode::kEmulationMode);
     setStickDefaultMapping(stick->ID, Event::NoType, EventMode::kMenuMode);
+    setStickDefaultMapping(stick->ID, Event::NoType, EventMode::kEmulationMode);
   }
 
   ostringstream buf;


### PR DESCRIPTION
For some controllers, the initial default (i.e. when the controller
is first attached) mappings seem to not work in emulation mode, but
work just fine in menu mode. The emulation mode mappings are shown
in the UI, but do not work until the second time the emulator is
started.

From debugging, even in emulation mode the joyMap is returning
menu bindings when in-game. Fix this bug by adding the emulation
mode mappings before the menu mode mappings.

Fixes: a7189ce7ec6f ("fix attempt for #692")
Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>