### PR TITLE
Paddle mode enhancements

### DIFF
--- a/src/common/PJoystickHandler.hxx
+++ b/src/common/PJoystickHandler.hxx
@@ -201,6 +201,10 @@ class PhysicalJoystickHandler
     static EventMappingArray DefaultRightJoystickMapping;
     static EventMappingArray DefaultLeftPaddlesMapping;
     static EventMappingArray DefaultRightPaddlesMapping;
+    static EventMappingArray DefaultLeftAPaddlesMapping;
+    static EventMappingArray DefaultLeftBPaddlesMapping;
+    static EventMappingArray DefaultRightAPaddlesMapping;
+    static EventMappingArray DefaultRightBPaddlesMapping;
     static EventMappingArray DefaultLeftKeyboardMapping;
     static EventMappingArray DefaultRightKeyboardMapping;
     static EventMappingArray DefaultLeftDrivingMapping;

--- a/src/emucore/Paddles.hxx
+++ b/src/emucore/Paddles.hxx
@@ -206,20 +206,26 @@ class Paddles : public Controller
 
     AnalogReadout::Connection getReadOut(int lastAxis, int& newAxis, int center);
 
+    void updateA();
+    void updateB();
+
     /**
       Update the axes pin state according to the events currently set.
     */
-    bool updateAnalogAxes();
+    bool updateAnalogAxesA();
+    bool updateAnalogAxesB();
 
     /**
       Update the entire state according to mouse events currently set.
     */
-    void updateMouse(bool& firePressedA, bool& firePressedB);
+    void updateMouseA(bool& firePressedA);
+    void updateMouseB(bool& firePressedB);
 
     /**
       Update the axes pin state according to the keyboard events currently set.
     */
-    void updateDigitalAxes();
+    void updateDigitalAxesA();
+    void updateDigitalAxesB();
 
   private:
     // Following constructors and assignment operators not supported


### PR DESCRIPTION
Map paddles to distinct controllers. For two player games, having both players share a single controller isn't ideal. Instead, put
- Left A -> joystick 0
- Left B -> joystick 1
- Right A -> joystick 2
- Right B -> joystick 3

and support up to four players with four controllers. This mostly amounts to having distinct defaults for each paddle, and untangling some of the internals.