### PR TITLE
Fixes for driving mode changes

### DIFF
--- a/src/emucore/Driving.cxx
+++ b/src/emucore/Driving.cxx
@@ -124,15 +124,15 @@ void Driving::updateControllerAxes()
   int a_axis = myEvent.get(myAnalogEvent);
 
   if( abs(a_axis) > Controller::analogDeadZone()) {
-    /* a_axis is in -2^15 to +2^15-1; dividing by 2^9 gives us -2^6 to
-       +2^6-1, which gives us roughly the same range as digital
-       inputs.
+    /* a_axis is in -2^15 to +2^15-1; adding 1 when non-negative and
+       dividing by 2^9 gives us -2^6 to +2^6, which gives us the same
+       range as digital inputs.
     */
-    myCounterHires += a_axis/512;
+    myCounterHires += (a_axis/512) + (a_axis >= 0);
   }
 
   // Only consider the lower-most bits (corresponding to pins 1 & 2)
-  myGrayIndex = Int32((myCounterHires / 256) * SENSITIVITY) & 0b11;
+  myGrayIndex = Int32((myCounterHires / 256.0) * SENSITIVITY) & 0b11;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/emucore/Event.hxx
+++ b/src/emucore/Event.hxx
@@ -183,7 +183,7 @@ class Event
     enum Group
     {
       Menu, Emulation,
-      Misc, AudioVideo, States, Console, Joystick, Paddles, Keyboard, Driving,
+      Misc, AudioVideo, States, Console, Joystick, Paddles, Driving, Keyboard,
       Devices,
       Debug, Combo,
       LastGroup


### PR DESCRIPTION
- Use a float divisor to reduce the high resolution counter to a gray
  code. This gives a more stable rate of change for the gray code when
  using a sensitivity other than 1.
- Slightly remap the axis space, so that the positive and negative
  ranges are the same. The new range is [64,-1] [1, 64]. We don't need
  zero, because of the analog dead zone.
- Reorder the Event enum as suggested for on PR860.

Contains some of the suggested changes arising from #860  