### PR TITLE
Update documentation for keybindings in Driving Mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -971,7 +971,7 @@
     </tr>
   </table>
 
-  <p><b>Driving Controller (cannot be remapped, always associated with joystick controller)</b></p>
+  <p><b>Driving Controller (can be remapped)</b></p>
 
   <table BORDER=2>
     <tr>
@@ -988,18 +988,18 @@
           </tr>
 
           <tr>
-            <td>Left Direction</td>
-            <td>Same as Left Joystick 'Left'</td>
+            <td>Counter Clockwise</td>
+            <td>Left arrow, Keypad 4</td>
           </tr>
 
           <tr>
-            <td>Right Direction</td>
-            <td>Same as Left Joystick 'Right'</td>
+            <td>Clockwise</td>
+            <td>Right arrow, Keypad 6</td>
           </tr>
 
           <tr>
             <td>Fire Button</td>
-            <td>Same as Left Joystick 'Fire'</td>
+            <td>Left Control, Space, Keypad 5</td>
           </tr>
         </table>
       </td>
@@ -1012,18 +1012,18 @@
           </tr>
 
           <tr>
-            <td>Left Direction</td>
-            <td>Same as Right Joystick 'Left'</td>
+            <td>Counter Clockwise</td>
+            <td>G</td>
           </tr>
 
           <tr>
-            <td>Right Direction</td>
-            <td>Same as Right Joystick 'Right'</td>
+            <td>Clockwise</td>
+            <td>J</td>
           </tr>
 
           <tr>
             <td>Fire Button</td>
-            <td>Same as Right Joystick 'Fire'</td>
+            <td>F</td>
           </tr>
         </table>
       </td>


### PR DESCRIPTION
The default keybindings remain the same as they did, they are just no longer shared with the Joystick Mode.