### PR TITLE
Add a GitHub action to build on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,29 @@ jobs:
       - name: Build Stella
         run: |
           ./configure && make -j3 all
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [x64, Win32]
+    env:
+      Platform: ${{ matrix.platform }}
+      SDL2_version: 2.24.0
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Set up MSBUILD
+        uses: microsoft/setup-msbuild@ab534842b4bdf384b8aaf93765dc6f721d9f5fab
+      - name: Install SDL2
+        shell: cmd
+        run: |
+          curl -o "C:\SDL2-devel.zip" "https://www.libsdl.org/release/SDL2-devel-%SDL2_version%-VC.zip"
+          7z x "C:\SDL2-devel.zip" -o"C:\"
+          xcopy /S "C:\SDL2-%SDL2_version%\include" src\common
+          if %Platform%==x64 xcopy /S "C:\SDL2-%SDL2_version%\lib\x64" src\os\windows
+          if %Platform%==Win32 xcopy /S "C:\SDL2-%SDL2_version%\lib\x86" src\os\windows
+      - name: Build Stella
+        run: |
+          msbuild src\os\windows\Stella.sln


### PR DESCRIPTION
This reproduces the Appveyor build for 32- and 64-bit Windows.

Signed-off-by: Stephen Kitt <steve@sk2.org>