### PR TITLE
add Joy2B+ support to libretro

### DIFF
--- a/src/os/libretro/libretro.cxx
+++ b/src/os/libretro/libretro.cxx
@@ -86,6 +86,10 @@ static void update_input()
     case Controller::Type::Genesis:
       MASK_EVENT(Event::LeftJoystickFire5, pad, RETRO_DEVICE_ID_JOYPAD_A);
       [[fallthrough]];
+    case Controller::Type::Joy2BPlus:
+      MASK_EVENT(Event::LeftJoystickFire9, pad, RETRO_DEVICE_ID_JOYPAD_Y);
+      MASK_EVENT(Event::LeftJoystickFire5, pad, RETRO_DEVICE_ID_JOYPAD_A);
+      [[fallthrough]];
     case Controller::Type::Joystick:
       MASK_EVENT(Event::LeftJoystickLeft, pad, RETRO_DEVICE_ID_JOYPAD_LEFT);
       MASK_EVENT(Event::LeftJoystickRight, pad, RETRO_DEVICE_ID_JOYPAD_RIGHT);
@@ -141,6 +145,10 @@ static void update_input()
       [[fallthrough]];
     case Controller::Type::Genesis:
       MASK_EVENT(Event::RightJoystickFire5, pad, RETRO_DEVICE_ID_JOYPAD_A);
+      [[fallthrough]];
+    case Controller::Type::Joy2BPlus:
+      MASK_EVENT(Event::LeftJoystickFire9, pad, RETRO_DEVICE_ID_JOYPAD_Y);
+      MASK_EVENT(Event::LeftJoystickFire5, pad, RETRO_DEVICE_ID_JOYPAD_A);
       [[fallthrough]];
     case Controller::Type::Joystick:
       MASK_EVENT(Event::RightJoystickLeft, pad, RETRO_DEVICE_ID_JOYPAD_LEFT);


### PR DESCRIPTION
fixes #949 and returns input to Elevator Agent game.

I just did brief testing with Elevator Agent, so I don't know if this would have any farther reaching implications for other games. Just let me know if so.