### PR TITLE
libretro: fix gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,48 +76,62 @@ libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
     - .core-defs
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:latest
+  before_script:
+    - export NUMPROC=$(($(nproc)/5))
+    - sudo apt-get update -qy
+    - sudo apt-get install -qy software-properties-common
+    - sudo add-apt-repository -y ppa:savoury1/build-tools
+    - sudo add-apt-repository -y ppa:savoury1/gcc-defaults-12
+    - sudo apt-get update -qy
+    - sudo apt-get install -qy gcc-12 g++-12
+  # This container's existing installations of gcc and CMake are way too old
+  variables:
+    CC: /usr/bin/gcc-12
+    CXX: /usr/bin/g++-12
+    CXXFLAGS: -Wno-deprecated-declarations # Deprecation warnings aren't helpful on the libretro Gitlab
 
 # MacOS 64-bit
 libretro-build-osx-x64:
+  tags:
+    - mac-apple-silicon
   extends:
     - .libretro-osx-x64-make-default
     - .core-defs
 
 # MacOS ARM 64-bit
 libretro-build-osx-arm64:
+  tags:
+    - mac-apple-silicon
   extends:
     - .libretro-osx-arm64-make-default
     - .core-defs
 
 ################################### CELLULAR #################################
 # Android ARMv7a
-android-armeabi-v7a:
-  extends:
-    - .libretro-android-jni-armeabi-v7a
-    - .core-defs
+# android-armeabi-v7a:
+#   extends:
+#     - .libretro-android-jni-armeabi-v7a
+#     - .core-defs
 
 # Android ARMv8a
-android-arm64-v8a:
-  extends:
-    - .libretro-android-jni-arm64-v8a
-    - .core-defs
+# android-arm64-v8a:
+#   extends:
+#     - .libretro-android-jni-arm64-v8a
+#     - .core-defs
 
 # Android 64-bit x86
-android-x86_64:
-  extends:
-    - .libretro-android-jni-x86_64
-    - .core-defs
+# android-x86_64:
+#   extends:
+#     - .libretro-android-jni-x86_64
+#     - .core-defs
 
 # iOS
 libretro-build-ios-arm64:
+  tags:
+    - mac-apple-silicon
   extends:
     - .libretro-ios-arm64-make-default
-    - .core-defs
-
-# iOS (armv7) [iOS 9 and up]
-libretro-build-ios9:
-  extends:
-    - .libretro-ios9-make-default
     - .core-defs
 
 # tvOS
@@ -128,7 +142,7 @@ libretro-build-tvos-arm64:
 
 ################################### CONSOLES #################################
 # Nintendo Switch
-libretro-build-libnx-aarch64:
-  extends:
-    - .libretro-libnx-static-retroarch-master
-    - .core-defs
+# libretro-build-libnx-aarch64:
+#   extends:
+#     - .libretro-libnx-static-retroarch-master
+#     - .core-defs

--- a/src/os/libretro/Makefile
+++ b/src/os/libretro/Makefile
@@ -64,9 +64,6 @@ ifneq (,$(findstring unix,$(platform)))
    ifeq ($(GPP_MAJOR),)
       $(error Unable to determine $(CXX) version)
    endif
-   ifeq "$(shell [ $(GPP_MAJOR) -lt 10 ]; echo $$?)" "0"
-      CXXFLAGS := $(subst -std=c++20,-std=c++2a,$(CXXFLAGS))
-   endif
    CXXFLAGS += $(LTO)
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS) $(call GET_STATIC_ARG,libgcc) $(call GET_STATIC_ARG,libstdc++)
    TARGET := $(TARGET_NAME)_libretro.so
@@ -88,13 +85,6 @@ ifneq (,$(findstring unix,$(platform)))
 
 # OS X
 else ifeq ($(platform), osx)
-   XCODE_MAJOR := $(shell xcodebuild -version | grep -oE 'Xcode ([0-9]+)' | cut -d ' ' -f 2)
-   ifeq ($(XCODE_MAJOR),)
-      $(error Unable to determine Xcode version)
-   endif
-   ifeq "$(shell [ $(XCODE_MAJOR) -lt 14 ]; echo $$?)" "0"
-      CXXFLAGS := $(subst -std=c++20,-std=c++2a,$(CXXFLAGS))
-   endif
    CXXFLAGS += $(LTO) -stdlib=libc++
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
    TARGET := $(TARGET_NAME)_libretro.dylib
@@ -108,21 +98,17 @@ else ifeq ($(platform), osx)
    ifeq ($(arch),ppc)
       CXXFLAGS += -DBLARGG_BIG_ENDIAN=1 -D__ppc__
    endif
-   OSXVER = $(shell sw_vers -productVersion | cut -d. -f 2)
-   OSX_GT_MOJAVE = $(shell (( $(OSXVER) >= 14)) && echo "YES")
-   ifneq ($(OSX_GT_MOJAVE),YES)
-      #this breaks compiling on Mac OS Mojave
-      MINVERSION = -mmacosx-version-min=10.7
-   endif
    fpic += $(MINVERSION)
 
    ifeq ($(CROSS_COMPILE),1)
-		TARGET_RULE   = -target $(LIBRETRO_APPLE_PLATFORM) -isysroot $(LIBRETRO_APPLE_ISYSROOT)
-		CFLAGS   += $(TARGET_RULE)
-		CPPFLAGS += $(TARGET_RULE)
-		CXXFLAGS += $(TARGET_RULE)
-		LDFLAGS  += $(TARGET_RULE)
+      TARGET_RULE   = -target $(LIBRETRO_APPLE_PLATFORM)
+   else
+      TARGET_RULE   = -target x86_64-apple-macos10.13
    endif
+   CFLAGS   += $(TARGET_RULE)
+   CPPFLAGS += $(TARGET_RULE)
+   CXXFLAGS += $(TARGET_RULE)
+   LDFLAGS  += $(TARGET_RULE)
 
    CFLAGS    += $(ARCHFLAGS)
    CXXFLAGS  += $(ARCHFLAGS)
@@ -130,13 +116,6 @@ else ifeq ($(platform), osx)
 
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
-   XCODE_MAJOR := $(shell xcodebuild -version | grep -oE 'Xcode ([0-9]+)' | cut -d ' ' -f 2)
-   ifeq ($(XCODE_MAJOR),)
-      $(error Unable to determine Xcode version)
-   endif
-   ifeq "$(shell [ $(XCODE_MAJOR) -lt 14 ]; echo $$?)" "0"
-      CXXFLAGS := $(subst -std=c++20,-std=c++2a,$(CXXFLAGS))
-   endif
    CXXFLAGS += $(LTO) -stdlib=libc++
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
    TARGET := $(TARGET_NAME)_libretro_ios.dylib
@@ -163,13 +142,6 @@ else ifneq (,$(findstring ios,$(platform)))
 
 # tvOS
 else ifeq ($(platform), tvos-arm64)
-   XCODE_MAJOR := $(shell xcodebuild -version | grep -oE 'Xcode ([0-9]+)' | cut -d ' ' -f 2)
-   ifeq ($(XCODE_MAJOR),)
-      $(error Unable to determine Xcode version)
-   endif
-   ifeq "$(shell [ $(XCODE_MAJOR) -lt 14 ]; echo $$?)" "0"
-      CXXFLAGS := $(subst -std=c++20,-std=c++2a,$(CXXFLAGS))
-   endif
    CXXFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
    LDFLAGS += $(LTO) $(PTHREAD_FLAGS) -stdlib=libc++
    TARGET := $(TARGET_NAME)_libretro_tvos.dylib


### PR DESCRIPTION
The Android builder seems to only go up through c++2a; it fails when trying to `#include <numbers>`. Hopefully I can come back to this at some point.

Nintendo Switch seems to have proper C++20 support except that `strnlen` isn't defined? Also the Docker container does not seem to be building for me so I can't test it locally to see why not. Hopefully I can also come back to this at some point.