### PR TITLE
Debian build requires libgtest-dev, but is not specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ a.out
 *.json
 *.sqlite3
 *.bak
+debian/files

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Maintainer: Stephen Anthony <sa666666@gmail.com>
 Section: otherosfs
 Priority: optional
 Build-Depends: debhelper (>= 10~),
+               libgtest-dev,
                libpng-dev,
                libsdl2-dev,
                zlib1g-dev


### PR DESCRIPTION
Found this one when trying to build on Raspberry Pi.