### PR TITLE
libretro: add webOS to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,9 @@ include:
     file: '/tvos-arm64.yml'
 
   #################################### MISC ##################################
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
 
 # Stages for building
 stages:
@@ -143,3 +146,10 @@ libretro-build-tvos-arm64:
 #   extends:
 #     - .libretro-libnx-static-retroarch-master
 #     - .core-defs
+
+#################################### MISC ##################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs


### PR DESCRIPTION
This adds the core to the libretro buildbot for webOS