### PR TITLE
Fix missing <climits> and <iomanip> includes

### DIFF
--- a/src/emucore/CartELF.cxx
+++ b/src/emucore/CartELF.cxx
@@ -15,6 +15,7 @@
 // this file, and for a DISCLAIMER OF ALL WARRANTIES.
 //============================================================================
 
+#include <iomanip>
 #include <sstream>
 
 #include "FSNode.hxx"

--- a/src/emucore/M6502.hxx
+++ b/src/emucore/M6502.hxx
@@ -34,6 +34,7 @@ class DispatchResult;
   #include "TimerMap.hxx"
 #endif
 
+#include <climits>
 #include "bspf.hxx"
 #include "Device.hxx"
 #include "Serializable.hxx"


### PR DESCRIPTION
`Add <climits> to M6502.hxx for ULLONG_MAX and <iomanip> to CartELF.cxx for std::setw/std::setfill, which are not transitively included`

Fixes:
```
CXX ../../emucore/CartAR.cxx
/build/build.LibreELEC-ARMv7.arm-13.0-devel/toolchain/bin/armv7a-libreelec-linux-gnueabihf-g++ -I. -I../.. -I../../os/libretro -I../../emucore -I../../emucore/elf -I../../emucore/tia -I../../common -I../../common/audio -I../../common/tv_filters -I../../common/repository/sqlite -I../../lib/json -I../../lib/httplib -I../../lib/sqlite  -march=armv7-a -mtune=cortex-a8 -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mfloat-abi=hard -mfpu=neon-vfpv3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -std=c++20 -fno-rtti -DGIT_VERSION=\"" 215d6661"\" -flto -O3 -DNDEBUG  -Wall -W -Wno-unused-parameter -fPIC -D__LIB_RETRO__ -DSOUND_SUPPORT -MMD -DHAVE_STDINT_H -DHAVE_STRINGS_H -fno-rtti -pedantic -c -o../../emucore/CartAR.o ../../emucore/CartAR.cxx
In file included from ../../emucore/CartAR.cxx:20:
../../emucore/M6502.hxx:377:29: error: 'ULLONG_MAX' was not declared in this scope
  377 |     uInt64 myLastBreakCycle{ULLONG_MAX};
      |                             ^~~~~~~~~~
../../emucore/M6502.hxx:39:1: note: 'ULLONG_MAX' is defined in header '<climits>'; this is probably fixable by adding '#include <climits>'
   38 | #include "Device.hxx"
  +++ |+#include <climits>
   39 | #include "Serializable.hxx"
../../emucore/M6502.hxx:377:39: error: cannot convert '<brace-enclosed initializer list>' to 'uInt64' {aka 'long long unsigned int'} in initialization
  377 |     uInt64 myLastBreakCycle{ULLONG_MAX};
      |                                       ^
```
and 
```
CXX ../../emucore/EventHandler.cxx
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -I. -I../.. -I../../os/libretro -I../../emucore -I../../emucore/elf -I../../emucore/tia -I../../common -I../../common/audio -I../../common/tv_filters -I../../common/repository/sqlite -I../../lib/json -I../../lib/httplib -I../../lib/sqlite  -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -std=c++20 -fno-rtti -DGIT_VERSION=\"" 5f70df8a38"\" -flto -O3 -DNDEBUG  -Wall -W -Wno-unused-parameter -fPIC -D__LIB_RETRO__ -DSOUND_SUPPORT -MMD -DHAVE_STDINT_H -DHAVE_STRINGS_H -fno-rtti -pedantic -c -o../../emucore/EventHandler.o ../../emucore/EventHandler.cxx
../../emucore/CartELF.cxx: In function 'void {anonymous}::dumpLinkage(const ElfParser&, const ElfLinker&, std::ostream&':
../../emucore/CartELF.cxx:77:32: error: 'setfill' is not a member of 'std'
   77 |     stream << std::hex << std::setfill('0');
      |                                ^~~~~~~
../../emucore/CartELF.cxx:35:1: note: 'std::setfill' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
   34 | #include "CartELF.hxx"
  +++ |+#include <iomanip>
   35 |
../../emucore/CartELF.cxx:80:44: error: 'setw' is not a member of 'std'
   80 |       << "\ntext segment size: 0x" << std::setw(8) << linker.getSegmentSize(ElfLinker::SegmentType::text)
      |                                            ^~~~
../../emucore/CartELF.cxx:80:44: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:81:44: error: 'setw' is not a member of 'std'
   81 |       << "\ndata segment size: 0x" << std::setw(8) << linker.getSegmentSize(ElfLinker::SegmentType::data)
      |                                            ^~~~
../../emucore/CartELF.cxx:81:44: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:82:46: error: 'setw' is not a member of 'std'
   82 |       << "\nrodata segment size: 0x" << std::setw(8) << linker.getSegmentSize(ElfLinker::SegmentType::rodata)
      |                                              ^~~~
../../emucore/CartELF.cxx:82:46: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:95:28: error: 'setw' is not a member of 'std'
   95 |         << " @ 0x" << std::setw(8)
      |                            ^~~~
../../emucore/CartELF.cxx:95:28: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:97:31: error: 'setw' is not a member of 'std'
   97 |         << " size 0x" << std::setw(8) << sections[i].size << '\n';
      |                               ^~~~
../../emucore/CartELF.cxx:97:31: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:110:28: error: 'setw' is not a member of 'std'
  110 |         << " = 0x" << std::setw(8) << relocatedSymbols[i]->value;
      |                            ^~~~
../../emucore/CartELF.cxx:110:28: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:143:35: error: 'setw' is not a member of 'std'
  143 |         stream << " * 0x" << std::setw(8) <<  address << '\n';
      |                                   ^~~~
../../emucore/CartELF.cxx:143:35: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:150:35: error: 'setw' is not a member of 'std'
  150 |         stream << " * 0x" << std::setw(8) <<  address << '\n';
      |                                   ^~~~
../../emucore/CartELF.cxx:150:35: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx: In member function 'void CartridgeELF::parseAndLinkElf()':
../../emucore/CartELF.cxx:498:27: error: 'setw' is not a member of 'std'
  498 |       << std::hex << std::setw(8) << std::setfill('0') << myArmEntrypoint
      |                           ^~~~
../../emucore/CartELF.cxx:498:27: note: 'std::setw' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
../../emucore/CartELF.cxx:498:43: error: 'setfill' is not a member of 'std'
  498 |       << std::hex << std::setw(8) << std::setfill('0') << myArmEntrypoint
      |                                           ^~~~~~~
../../emucore/CartELF.cxx:498:43: note: 'std::setfill' is defined in header '<iomanip>'; this is probably fixable by adding '#include <iomanip>'
make: *** [Makefile:650: ../../emucore/CartELF.o] Error 1
```