### PR TITLE
ci: add Linux arm64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-arm64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -80,6 +84,17 @@ libretro-build-linux-x64:
     - .libretro-linux-x64-make-default
     - .core-defs
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
+  variables:
+    CC: /usr/bin/gcc-12
+    CXX: /usr/bin/g++-12
+    CXXFLAGS: -Wno-deprecated-declarations # Deprecation warnings aren't helpful on the libretro Gitlab
+
+# Linux ARM 64-bit
+libretro-build-linux-arm64:
+  extends:
+    - .libretro-linux-arm64-make-default
+    - .core-defs
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-arm64-ubuntu:backports
   variables:
     CC: /usr/bin/gcc-12
     CXX: /usr/bin/g++-12


### PR DESCRIPTION
Adds a Linux arm64 (aarch64) libretro build to the GitLab CI, alongside the existing Linux x64 job.

This fills the only gap among the libretro arm64 targets — macOS, Android, iOS and tvOS arm64 cores were already built, but Linux aarch64 was missing.

## Changes
- Include the `linux-arm64.yml` libretro-infrastructure CI template.
- Add the `libretro-build-linux-arm64` job (mirrors `libretro-build-linux-x64`, using the `libretro-build-arm64-ubuntu` image and gcc-12).

## Testing
Built the core natively on aarch64 (`platform=unix`, the same path the CI job uses) and verified it runs: loaded Berzerk in a libretro frontend and confirmed correct video/audio output.