### PR TITLE
ci: fix the Linux ARM64 libretro build (arm64 -> aarch64)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ include:
 
   # Linux ARM 64-bit
   - project: 'libretro-infrastructure/ci-templates'
-    file: '/linux-arm64.yml'
+    file: '/linux-aarch64.yml'
 
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
@@ -90,14 +90,11 @@ libretro-build-linux-x64:
     CXXFLAGS: -Wno-deprecated-declarations # Deprecation warnings aren't helpful on the libretro Gitlab
 
 # Linux ARM 64-bit
-libretro-build-linux-arm64:
+libretro-build-linux-aarch64:
   extends:
-    - .libretro-linux-arm64-make-default
+    - .libretro-linux-aarch64-make-default
     - .core-defs
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-arm64-ubuntu:backports
   variables:
-    CC: /usr/bin/gcc-12
-    CXX: /usr/bin/g++-12
     CXXFLAGS: -Wno-deprecated-declarations # Deprecation warnings aren't helpful on the libretro Gitlab
 
 # MacOS 64-bit


### PR DESCRIPTION
Follow-up to #1154, which I got wrong: the template it references does not exist, so the job it adds cannot work.

It has no visible effect here, because GitHub never evaluates `.gitlab-ci.yml` — the file only matters on libretro's GitLab, and the mirror there builds a `stella2026` branch that does not carry this change. The same patch applied to the `stella2023` core repo, where GitLab *does* read it, broke the CI pipelines and was reverted within the hour (libretro/stella2023#8, reverted by #9). So this is a latent breakage rather than a working configuration.

**Three things were wrong:**

1. `file: '/linux-arm64.yml'` — `libretro-infrastructure/ci-templates` has no such file. The desktop Linux ARM template is `/linux-aarch64.yml`. GitLab resolves `include:` while *creating* the pipeline, so a missing template does not fail one job, it prevents any pipeline from being generated — every platform breaks at once.
2. `.libretro-linux-arm64-make-default` — same naming problem; the template defines `.libretro-linux-aarch64-make-default`.
3. `image: ...libretro-build-arm64-ubuntu:backports` — that image does not exist either. The registry has `libretro-build-aarch64-ubuntu`, and it has no `backports` tag (only `latest`/`main`).

Only the Apple targets use `arm64` in this ecosystem (`osx-arm64.yml`, `ios-arm64.yml`, `tvos-arm64.yml`), which is what made the wrong spelling look reasonable when mirroring the x64 job.

**The fix** drops the image and compiler overrides entirely and uses the template defaults, keeping only the warning suppression the x64 job carries. The overrides are unnecessary on this target: `libretro-build-aarch64-ubuntu:latest` installs gcc-12/g++-12 and points `gcc`/`g++` at them through `update-alternatives`, so `CC: gcc` from the template is already gcc-12.

Verified before opening: the core builds clean on real aarch64 hardware (`cd src/os/libretro && make platform=unix` → `stella_libretro.so`).