### PR TITLE
libretro: update NDK as per buildbot, fix compile issue without CHEATCODE_SUPPORT

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,7 +120,7 @@ android-armeabi-v7a:
     - .libretro-android-jni-armeabi-v7a
     - .core-defs
   variables:
-    NDK_ROOT: /android-sdk-linux/ndk/26.2.11394342
+    NDK_ROOT: /android-sdk-linux/ndk/29.0.14206865
 
 # Android ARMv8a
 android-arm64-v8a:
@@ -128,7 +128,7 @@ android-arm64-v8a:
     - .libretro-android-jni-arm64-v8a
     - .core-defs
   variables:
-    NDK_ROOT: /android-sdk-linux/ndk/26.2.11394342
+    NDK_ROOT: /android-sdk-linux/ndk/29.0.14206865
 
 # Android 64-bit x86
 android-x86_64:
@@ -136,7 +136,7 @@ android-x86_64:
     - .libretro-android-jni-x86_64
     - .core-defs
   variables:
-    NDK_ROOT: /android-sdk-linux/ndk/26.2.11394342
+    NDK_ROOT: /android-sdk-linux/ndk/29.0.14206865
 
 # iOS
 libretro-build-ios-arm64:

--- a/src/emucore/OSystem.cxx
+++ b/src/emucore/OSystem.cxx
@@ -127,7 +127,9 @@ bool OSystem::initialize(const Settings::Options& options)
     "State directory:    '{}'\n"
     "NVRam directory:    '{}'\n"
     "Persistence:        '{}'\n"
+#ifdef CHEATCODE_SUPPORT
     "Cheat file:         '{}'\n"
+#endif
     "Palette file:       '{}'\n",
     STELLA_VERSION,
     myFeatures,
@@ -136,7 +138,9 @@ bool OSystem::initialize(const Settings::Options& options)
     AsciiFold::toAscii(stateDir().getShortPath()),
     AsciiFold::toAscii(nvramDir().getShortPath()),
     AsciiFold::toAscii(describePersistence()),
+#ifdef CHEATCODE_SUPPORT
     AsciiFold::toAscii(cheatFile().getShortPath()),
+#endif
     AsciiFold::toAscii(paletteFile().getShortPath())));
 
   // NOTE: The framebuffer MUST be created before any other object!!!


### PR DESCRIPTION
Hi,

We have updated the Android NDK on the libretro buildbot to v29 as we are trying to get RA back on the playstore. I have updated in the gitlab-ci here. I've tested compilation locally with that version and it worked.

Also fixes following compiler error I had locally:

```
/home/cscd98/Developer/stella/src/os/libretro/jni/../../../emucore/OSystem.cxx:139:24: error: use of undeclared identifier 'cheatFile'
  139 |     AsciiFold::toAscii(cheatFile().getShortPath()),
      |                        ^
1 error generated.
make: *** [/home/cscd98/Android/Sdk/ndk/29.0.14206865/build/core/build-binary.mk:422: /home/cscd98/Developer/stella/src/os/libretro/obj/local/arm64-v8a/objs/retro//home/cscd98/Developer/stella/src/os/libretro/jni/__/__/__/emucore/OSystem.o] Error 
```
