### PR TITLE
libretro: do file I/O through the VFS, and don't pad the in-memory ROM

### DIFF
--- a/src/os/libretro/FSNodeLIBRETRO.cxx
+++ b/src/os/libretro/FSNodeLIBRETRO.cxx
@@ -28,6 +28,75 @@ extern string libretro_rom_path;           // NOLINT(cppcoreguidelines-avoid-non
 extern uInt32 libretro_read_rom(void* data);
 extern uInt32 libretro_get_rom_size();
 
+namespace {
+
+/**
+  Read an entire file through the frontend VFS.
+
+  @param path    The file to read (as the frontend understands it)
+  @param buffer  Receives the data
+  @param size    Maximum number of bytes to read (0 means the whole file)
+
+  @return  The number of bytes read, or 0 if the VFS could not read the file
+*/
+size_t vfsReadFile(const string& path, ByteArray& buffer, size_t size)
+{
+  if(!libretro_vfs || !libretro_vfs->open || !libretro_vfs->read)
+    return 0;
+
+  retro_vfs_file_handle* file = libretro_vfs->open(path.c_str(),
+      RETRO_VFS_FILE_ACCESS_READ, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+  if(!file)
+    return 0;
+
+  const int64_t fileSize = libretro_vfs->size(file);
+  if(fileSize <= 0)
+  {
+    libretro_vfs->close(file);
+    return 0;
+  }
+
+  // If a requested size to read is provided (size > 0), honour it
+  const size_t sizeToRead = (size > 0)
+    ? std::min(static_cast<size_t>(fileSize), size)
+    : static_cast<size_t>(fileSize);
+
+  buffer.resize(sizeToRead);
+  const int64_t bytesRead = libretro_vfs->read(file, buffer.data(), sizeToRead);
+  libretro_vfs->close(file);
+
+  if(bytesRead <= 0)
+    return 0;
+
+  buffer.resize(static_cast<size_t>(bytesRead));
+  return static_cast<size_t>(bytesRead);
+}
+
+/**
+  Write a buffer to a file through the frontend VFS.
+
+  @return  The number of bytes written, or 0 if the VFS could not write it
+*/
+size_t vfsWriteFile(const string& path, const void* data, size_t size)
+{
+  if(!libretro_vfs || !libretro_vfs->open || !libretro_vfs->write)
+    return 0;
+
+  retro_vfs_file_handle* file = libretro_vfs->open(path.c_str(),
+      RETRO_VFS_FILE_ACCESS_WRITE, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+  if(!file)
+    return 0;
+
+  const int64_t bytesWritten = libretro_vfs->write(file, data, size);
+  if(libretro_vfs->flush)
+    libretro_vfs->flush(file);
+  libretro_vfs->close(file);
+
+  return bytesWritten > 0 ? static_cast<size_t>(bytesWritten) : 0;
+}
+
+}  // namespace
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 FSNodeLIBRETRO::FSNodeLIBRETRO()
   : _path{libretro_save_dir.empty()
@@ -75,12 +144,19 @@ bool FSNodeLIBRETRO::setFlags()
       // the ROM from an archive and handed us an archive-relative path
       // (e.g. 'game.zip#game.a26')
       _isDirectory = false;
-      _isFile = _path == libretro_rom_path && libretro_get_rom_size() > 0;
+      _isFile = isMemoryROM();
       _size = _isFile ? libretro_get_rom_size() : 0;
       return _isFile;
     }
   }
   return false;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+bool FSNodeLIBRETRO::isMemoryROM() const
+{
+  return !_path.empty() && _path == libretro_rom_path &&
+         libretro_get_rom_size() > 0;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -94,7 +170,7 @@ bool FSNodeLIBRETRO::exists() const
 
     // File not found on disk; it may still be the in-memory ROM on platforms
     // where the ROM path isn't directly accessible (e.g. Android)
-    return _path == libretro_rom_path && libretro_get_rom_size() > 0;
+    return isMemoryROM();
   }
   return true;  // VFS unavailable: assume exists (backward-compatible fallback)
 }
@@ -202,20 +278,56 @@ bool FSNodeLIBRETRO::rename(string_view newfile)
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-size_t FSNodeLIBRETRO::read(ByteArray& image, size_t) const
+size_t FSNodeLIBRETRO::read(ByteArray& image, size_t size) const
 {
-  // If VFS confirms the file is on disk, return 0 so the base class reads
-  // it normally via openIFStream
-  if(libretro_vfs && libretro_vfs->stat)
-  {
-    int32_t unused = 0;
-    if(libretro_vfs->stat(_path.c_str(), &unused) & RETRO_VFS_STAT_IS_VALID)
-      return 0;
-  }
+  // Read through the frontend: the path may only be meaningful to it (Android
+  // SAF URIs, network shares), and where it is an ordinary path this still
+  // ends up as an ordinary file read
+  if(const size_t bytesRead = vfsReadFile(_path, image, size); bytesRead > 0)
+    return bytesRead;
 
-  // File not accessible on disk — serve the in-memory ROM buffer.
+  // File not accessible through the VFS — serve the in-memory ROM buffer.
   // This handles platforms (e.g. Android) where need_fullpath=false means
   // RetroArch loads the ROM into memory but the path isn't directly readable.
-  image.resize(Cartridge::maxSize());
-  return libretro_read_rom(image.data());
+  if(isMemoryROM())
+  {
+    image.resize(Cartridge::maxSize());
+    const size_t romSize = libretro_read_rom(image.data());
+
+    // Trim to what was actually there: callers hash and probe the buffer
+    // itself, so one padded out to maxSize() gives the wrong MD5 (and with
+    // it the wrong properties) and the wrong bankswitch type
+    image.resize(romSize);
+    return romSize;
+  }
+
+  // Let the base class fall back to a normal C++ stream
+  return 0;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+size_t FSNodeLIBRETRO::read(std::stringstream& buffer) const
+{
+  ByteArray data;
+
+  const size_t bytesRead = vfsReadFile(_path, data, 0);
+  if(bytesRead == 0)
+    return 0;
+
+  buffer.write(reinterpret_cast<const char*>(data.data()),
+               static_cast<std::streamsize>(bytesRead));
+
+  return buffer ? bytesRead : 0;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+size_t FSNodeLIBRETRO::write(ByteSpan buffer) const
+{
+  return vfsWriteFile(_path, buffer.data(), buffer.size());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+size_t FSNodeLIBRETRO::write(string_view buffer) const
+{
+  return vfsWriteFile(_path, buffer.data(), buffer.size());
 }

--- a/src/os/libretro/FSNodeLIBRETRO.hxx
+++ b/src/os/libretro/FSNodeLIBRETRO.hxx
@@ -24,9 +24,10 @@
 
 /*
  * Implementation of the Stella file system API based on the libretro VFS
- * (Virtual File System) interface.  Falls back to standard C++ file streams
- * for actual I/O, which work on all platforms where RetroArch provides real
- * filesystem paths.
+ * (Virtual File System) interface.  Metadata, directory operations and file
+ * I/O all go through the frontend; standard C++ file streams are only used
+ * when the frontend provides no VFS at all, in which case the paths are
+ * ordinary filesystem paths anyway.
  *
  * Parts of this class are documented in the base interface class,
  * AbstractFSNode.
@@ -66,11 +67,19 @@ class FSNodeLIBRETRO : public AbstractFSNode
     bool getChildren(AbstractFSList& list, ListMode mode) const override;
     AbstractFSNodePtr getParent() const override;
 
-    // Used to serve the in-memory ROM on platforms where the ROM file path
-    // is not directly accessible (e.g. Android with need_fullpath = false).
-    // Returns 0 when the file exists on disk so the base class uses openIFStream.
-    size_t read(ByteArray& image, size_t) const override;
+    // All file I/O goes through the frontend VFS, since the path may only be
+    // meaningful to the frontend (Android SAF URIs, network shares).  When the
+    // VFS cannot read the ROM path, the in-memory ROM is served instead, for
+    // platforms where need_fullpath = false means RetroArch has loaded it.
+    // Returning 0 lets the base class fall back to a normal C++ stream.
+    size_t read(ByteArray& image, size_t size) const override;
+    size_t read(std::stringstream& buffer) const override;
+    size_t write(ByteSpan buffer) const override;
+    size_t write(string_view buffer) const override;
 
+    // These remain plain C++ streams: a std::ifstream cannot be handed a
+    // VFS-backed stream buffer that outlives it.  Subsystems should prefer
+    // ::read and ::write above, as AbstractFSNode itself recommends.
     std::ifstream openIFStream(std::ios::openmode mode) const override {
       return std::ifstream(_path, mode);
     }
@@ -88,6 +97,14 @@ class FSNodeLIBRETRO : public AbstractFSNode
      * @return  true if the path was found and flags were set
      */
     bool setFlags();
+
+    /**
+     * Does this node refer to a ROM that only exists in memory?  With
+     * need_fullpath = false the frontend loads the ROM itself, and the path
+     * it hands over may not be resolvable (e.g. Android, or a path inside an
+     * archive that RetroArch has already extracted).
+     */
+    bool isMemoryROM() const;
 
   private:
     string _path, _displayName;


### PR DESCRIPTION
`FSNodeLIBRETRO` asks the frontend VFS for metadata and directory listings, but every actual read and write goes through a plain `std::ifstream`/`ofstream`. Where the frontend hands out a path only it can resolve — an Android SAF URI, a network share — `stat()` succeeds through the VFS while the C++ stream cannot open the same path, so loading a ROM from such a location fails outright, and files like a user palette are silently missed.

`AbstractFSNode` already has the hooks for this: `read()`/`write()` are asked first and only fall back to a stream when they return 0. This implements all four on top of the VFS interface, so a frontend path is opened by the frontend. The `openIFStream()`/`openOFStream()` overrides stay as they are — a `std::ifstream` cannot be handed a VFS-backed stream buffer that outlives it — and they remain correct whenever there is no VFS, since then the paths are ordinary filesystem paths anyway.

Two smaller things in the same file while I was there:

* `read()` padded the in-memory ROM buffer out to `Cartridge::maxSize()` and returned the real size, but callers hash and probe the buffer itself. A ROM served from memory (`need_fullpath = false`, e.g. Android) therefore got the MD5 of 512KB of mostly zeroes — so no per-ROM properties — and was detected as a 512K cart. It is now trimmed to the size actually read.
* the three copies of the "is this the in-memory ROM" condition became one `isMemoryROM()` helper.

## Testing

With a harness that hands the core a VFS whose paths cannot be resolved by the C library (`saf://…`), compared against the same ROM read normally:

| | before | after |
|---|---|---|
| VFS-only path | `File open/read error`, load fails | loads; user palette in the save dir is read through the VFS |
| ROM served from memory | MD5 `8a2311432cedab7f70920d25d3ba7ec7`, `4K* (512K)` | MD5 `46e9428848c9ea71a4d8f91ff81ac9cc`, `4K* (4K)` — same as the on-disk read |

Desktop behaviour is unchanged: RetroArch 1.22.2 (`GET_VFS_INTERFACE … providing V3`) boots the same ROM with the same MD5, cart type and display format, at full speed.